### PR TITLE
Fix: Render join invite code form inline inside empty state container

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { RoomCard } from "@/components/room/RoomCard";
-import { JoinModal } from "@/components/room/JoinModal";
+import { JoinInline } from "@/components/room/JoinModal";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -180,7 +180,7 @@ export default async function DashboardPage({
               <Button asChild>
                 <Link href="/room/create">Create your first room</Link>
               </Button>
-              <JoinModal />
+              <JoinInline />
             </div>
           </div>
         ) : (

--- a/components/room/JoinModal.tsx
+++ b/components/room/JoinModal.tsx
@@ -4,19 +4,17 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { X } from "lucide-react";
 
-export function JoinModal({
-  initialOpen = false,
+export function JoinInline({
   initialCode = "",
 }: {
-  initialOpen?: boolean;
   initialCode?: string;
 } = {}) {
   const router = useRouter();
-  const [open, setOpen] = useState(initialOpen);
+  const [open, setOpen] = useState(false);
   const [code, setCode] = useState(initialCode);
   const [teamName, setTeamName] = useState("");
   const [loading, setLoading] = useState(false);
@@ -46,31 +44,40 @@ export function JoinModal({
     }
   }
 
+  if (!open) {
+    return (
+      <Button variant="outline" size="lg" className="h-11 px-6 font-semibold" onClick={() => setOpen(true)}>
+        Join with code
+      </Button>
+    );
+  }
+
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button variant="outline" size="lg" className="h-11 px-6 font-semibold">
-          Join with code
-        </Button>
-      </DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Join with invite code</DialogTitle>
-        </DialogHeader>
-        <div className="space-y-3">
-          <div className="space-y-2">
-            <Label htmlFor="code">Invite code</Label>
-            <Input id="code" value={code} onChange={(e) => setCode(e.target.value.toUpperCase())} placeholder="ABC12X" />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="tname">Team name</Label>
-            <Input id="tname" value={teamName} onChange={(e) => setTeamName(e.target.value)} placeholder="Super Kings FC" />
-          </div>
-          <Button className="w-full" disabled={loading} onClick={join}>
-            Join
-          </Button>
+    <div className="mt-4 w-full max-w-sm mx-auto rounded-xl border border-white/10 bg-neutral-950/60 p-4 text-left">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold text-neutral-200">Join with invite code</h3>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="cursor-pointer rounded-sm opacity-70 transition-opacity hover:opacity-100"
+        >
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </button>
+      </div>
+      <div className="space-y-3">
+        <div className="space-y-2">
+          <Label htmlFor="code">Invite code</Label>
+          <Input id="code" value={code} onChange={(e) => setCode(e.target.value.toUpperCase())} placeholder="ABC12X" />
         </div>
-      </DialogContent>
-    </Dialog>
+        <div className="space-y-2">
+          <Label htmlFor="tname">Team name</Label>
+          <Input id="tname" value={teamName} onChange={(e) => setTeamName(e.target.value)} placeholder="Super Kings FC" />
+        </div>
+        <Button className="w-full" disabled={loading} onClick={join}>
+          Join
+        </Button>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
Closes #47

## Problem
The 'Join with invite code' form opened as a floating modal dialog (via Radix `<Dialog>` portal with `position: fixed`) that visually overflowed outside the dashed-border 'No auction rooms yet' container.

## Solution
Replaced the portal-based `JoinModal` with an inline `JoinInline` component that toggles the invite code form directly inside the container:

- **Collapsed state:** Renders the 'Join with code' button (unchanged UX)
- **Expanded state:** Shows the form (invite code, team name, join button) inline within the dashed-border box, with a close (✕) button to dismiss

## Files Changed
- `components/room/JoinModal.tsx` — Replaced `JoinModal` → `JoinInline`, removed Dialog/portal, added inline toggle
- `app/(app)/dashboard/page.tsx` — Updated import and usage
