### PR TITLE
Fix: Hide create button and center join form in empty state

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -176,10 +176,7 @@ export default async function DashboardPage({
             <p className="mt-2 text-sm text-neutral-500">
               Create one for your group or paste an invite code from your host.
             </p>
-            <div className="mt-6 flex flex-wrap justify-center gap-3">
-              <Button asChild>
-                <Link href="/room/create">Create your first room</Link>
-              </Button>
+            <div className="mt-6">
               <JoinInline />
             </div>
           </div>

--- a/components/room/JoinModal.tsx
+++ b/components/room/JoinModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -10,8 +11,10 @@ import { X } from "lucide-react";
 
 export function JoinInline({
   initialCode = "",
+  createRoomHref = "/room/create",
 }: {
   initialCode?: string;
+  createRoomHref?: string;
 } = {}) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
@@ -46,14 +49,19 @@ export function JoinInline({
 
   if (!open) {
     return (
-      <Button variant="outline" size="lg" className="h-11 px-6 font-semibold" onClick={() => setOpen(true)}>
-        Join with code
-      </Button>
+      <div className="flex flex-wrap justify-center gap-3">
+        <Button asChild>
+          <Link href={createRoomHref}>Create your first room</Link>
+        </Button>
+        <Button variant="outline" size="lg" className="h-11 px-6 font-semibold" onClick={() => setOpen(true)}>
+          Join with code
+        </Button>
+      </div>
     );
   }
 
   return (
-    <div className="mt-4 w-full max-w-sm mx-auto rounded-xl border border-white/10 bg-neutral-950/60 p-4 text-left">
+    <div className="w-full max-w-sm mx-auto rounded-xl border border-white/10 bg-neutral-950/60 p-4 text-left">
       <div className="flex items-center justify-between mb-3">
         <h3 className="text-sm font-semibold text-neutral-200">Join with invite code</h3>
         <button


### PR DESCRIPTION
Closes #47

## Problem
After clicking 'Join with code', the 'Create your first room' button remained visible and the invite code form was not centered inside the dashed-border container.

## Solution
- `JoinInline` now manages both buttons internally
- **Collapsed:** Shows 'Create your first room' + 'Join with code' side-by-side (unchanged)
- **Expanded:** Hides the create button, shows only the centered invite code form

## Files Changed
- `components/room/JoinModal.tsx` — Component now renders both buttons when collapsed; only centered form when expanded
- `app/(app)/dashboard/page.tsx` — Simplified wrapper since `JoinInline` handles button layout
