### PR TITLE
feat: universal /join/[code] route — auto-redirect unauthed users

### DIFF
--- a/app/(app)/league/p/[inviteCode]/page.tsx
+++ b/app/(app)/league/p/[inviteCode]/page.tsx
@@ -1,34 +1,11 @@
-import Link from "next/link";
 import { redirect } from "next/navigation";
-import { createClient } from "@/lib/supabase/server";
 
+/** Legacy route — all invite-code resolution now lives at /join/[code]. */
 export default async function PrivateLeagueInviteLanding({
   params,
 }: {
   params: Promise<{ inviteCode: string }>;
 }) {
   const { inviteCode } = await params;
-  const code = inviteCode.trim().toUpperCase();
-  const supabase = await createClient();
-
-  const { data: league } = await supabase
-    .from("fantasy_leagues")
-    .select("id, league_kind")
-    .eq("invite_code", code)
-    .eq("league_kind", "private")
-    .maybeSingle();
-
-  if (!league) {
-    return (
-      <div className="mx-auto max-w-md px-4 py-20 text-center">
-        <h1 className="aa-display text-xl font-semibold text-white">League not found</h1>
-        <p className="mt-2 text-sm text-neutral-500">Double-check the invite code.</p>
-        <Link href="/dashboard" className="mt-6 inline-block text-violet-300 hover:underline">
-          Dashboard
-        </Link>
-      </div>
-    );
-  }
-
-  redirect(`/league/private/${league.id}`);
+  redirect(`/join/${encodeURIComponent(inviteCode.trim())}`);
 }

--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -1,13 +1,13 @@
 import { createClient } from "@/lib/supabase/server";
 import { loginUrlWithNext } from "@/lib/safe-path";
+import { normalizeInviteCode, resolveJoinTarget } from "@/lib/join/resolve-invite-code";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { redirect } from "next/navigation";
 
 export default async function JoinPage({ params }: { params: Promise<{ code: string }> }) {
   const { code: raw } = await params;
-  const codeRaw = (raw ?? "").trim();
-  const code = codeRaw.toUpperCase();
+  const { code, codeRaw } = normalizeInviteCode(raw ?? "");
 
   const supabase = await createClient();
   const {
@@ -15,37 +15,27 @@ export default async function JoinPage({ params }: { params: Promise<{ code: str
   } = await supabase.auth.getUser();
 
   if (!user) {
-    // Preserve the join target through OAuth.
-    return (
-      <main className="mx-auto flex min-h-[70vh] max-w-xl flex-col items-center justify-center gap-4 px-6 text-center">
-        <h1 className="aa-display text-2xl font-semibold text-white">Sign in to join</h1>
-        <p className="text-sm text-neutral-500">We’ll send you right back after login.</p>
-        <Button asChild size="lg" className="h-11">
-          <Link href={loginUrlWithNext(`/join/${encodeURIComponent(code)}`)}>Continue</Link>
-        </Button>
-      </main>
-    );
+    redirect(loginUrlWithNext(`/join/${encodeURIComponent(code)}`));
   }
 
-  // Auction room invite?
   const { data: room } = await supabase
     .from("auction_rooms")
     .select("id")
     .in("invite_code", [code, codeRaw])
     .maybeSingle();
-  if (room?.id) {
-    redirect(`/room/${room.id}/lobby`);
-  }
 
-  // Private league invite?
-  const { data: league } = await supabase
-    .from("fantasy_leagues")
-    .select("id, league_kind")
-    .in("invite_code", [code, codeRaw])
-    .maybeSingle();
-  if (league?.id) {
-    const dest = league.league_kind === "private" ? `/league/private/${league.id}` : `/league/${league.id}`;
-    redirect(dest);
+  const { data: league } = room?.id
+    ? { data: null }
+    : await supabase
+        .from("fantasy_leagues")
+        .select("id, league_kind")
+        .in("invite_code", [code, codeRaw])
+        .maybeSingle();
+
+  const target = resolveJoinTarget(room, league);
+
+  if (target.kind !== "not-found") {
+    redirect(target.url);
   }
 
   return (

--- a/lib/join/resolve-invite-code.test.ts
+++ b/lib/join/resolve-invite-code.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { normalizeInviteCode, resolveJoinTarget } from "./resolve-invite-code";
+
+describe("normalizeInviteCode", () => {
+  it("trims and uppercases", () => {
+    expect(normalizeInviteCode("  abc12x ")).toEqual({ code: "ABC12X", codeRaw: "abc12x" });
+  });
+
+  it("handles already-uppercase input", () => {
+    expect(normalizeInviteCode("9HVXGC")).toEqual({ code: "9HVXGC", codeRaw: "9HVXGC" });
+  });
+
+  it("handles empty string", () => {
+    expect(normalizeInviteCode("")).toEqual({ code: "", codeRaw: "" });
+  });
+
+  it("handles whitespace-only", () => {
+    expect(normalizeInviteCode("   ")).toEqual({ code: "", codeRaw: "" });
+  });
+});
+
+describe("resolveJoinTarget", () => {
+  it("resolves auction room", () => {
+    const result = resolveJoinTarget({ id: "room-uuid" }, null);
+    expect(result).toEqual({ kind: "room", url: "/room/room-uuid/lobby" });
+  });
+
+  it("resolves private league", () => {
+    const result = resolveJoinTarget(null, { id: "league-uuid", league_kind: "private" });
+    expect(result).toEqual({ kind: "league", url: "/league/private/league-uuid" });
+  });
+
+  it("resolves auction league", () => {
+    const result = resolveJoinTarget(null, { id: "league-uuid", league_kind: "auction" });
+    expect(result).toEqual({ kind: "league", url: "/league/league-uuid" });
+  });
+
+  it("prefers room over league when both match", () => {
+    const result = resolveJoinTarget(
+      { id: "room-uuid" },
+      { id: "league-uuid", league_kind: "private" },
+    );
+    expect(result).toEqual({ kind: "room", url: "/room/room-uuid/lobby" });
+  });
+
+  it("returns not-found when neither match", () => {
+    expect(resolveJoinTarget(null, null)).toEqual({ kind: "not-found" });
+    expect(resolveJoinTarget(undefined, undefined)).toEqual({ kind: "not-found" });
+  });
+});

--- a/lib/join/resolve-invite-code.ts
+++ b/lib/join/resolve-invite-code.ts
@@ -1,0 +1,22 @@
+export type JoinTarget =
+  | { kind: "room"; url: string }
+  | { kind: "league"; url: string }
+  | { kind: "not-found" };
+
+export function resolveJoinTarget(
+  room: { id: string } | null | undefined,
+  league: { id: string; league_kind: string } | null | undefined,
+): JoinTarget {
+  if (room?.id) return { kind: "room", url: `/room/${room.id}/lobby` };
+  if (league?.id) {
+    const url =
+      league.league_kind === "private" ? `/league/private/${league.id}` : `/league/${league.id}`;
+    return { kind: "league", url };
+  }
+  return { kind: "not-found" };
+}
+
+export function normalizeInviteCode(raw: string): { code: string; codeRaw: string } {
+  const codeRaw = (raw ?? "").trim();
+  return { code: codeRaw.toUpperCase(), codeRaw };
+}


### PR DESCRIPTION
## Summary
Closes #26

Completes the universal `/join/[code]` route so it fully matches the issue spec.

### Changes

1. **Auto-redirect unauthed users** — replaced the "Sign in to join" interstitial page (with a manual Continue button) with an instant `redirect()` to `/login?next=/join/{code}`. This matches the flow: friend clicks link → login → OAuth → back to `/join/{code}` → room/league.

2. **Extracted resolution logic** into `lib/join/resolve-invite-code.ts` (`normalizeInviteCode` + `resolveJoinTarget`) for testability and reuse.

3. **Deprecated `/league/p/[inviteCode]`** — now redirects to `/join/[code]` so all invite codes funnel through one route.

4. **Added 9 unit tests** covering code normalization and target resolution (room, private league, auction league, precedence, invalid).

### Verification

```
curl -s -o /dev/null -w '%{http_code} → %{redirect_url}' http://localhost:3000/join/TESTROOM
# 307 → /login?next=%2Fjoin%2FTESTROOM  (was HTTP 200 with button page)
```

All 92 tests pass. Build succeeds.