### PR TITLE
feat: readable match names in leaderboard & owner names in trade history

### DIFF
--- a/app/(app)/league/private/[leagueId]/page.tsx
+++ b/app/(app)/league/private/[leagueId]/page.tsx
@@ -385,6 +385,7 @@ export default async function PrivateLeaguePage({ params }: { params: Promise<{ 
                       myTeamId={myClaimedTeamId}
                       playersById={tradesPlayersById}
                       teamsById={tradesTeamsById}
+                      ownersByTeamId={ownersByTeamId}
                     />
                   ) : (
                     <p className="py-6 text-center text-sm text-neutral-500">

--- a/components/league/LeagueClient.tsx
+++ b/components/league/LeagueClient.tsx
@@ -38,7 +38,7 @@ export function LeagueClient({
   myTeamId?: string;
 }) {
   const router = useRouter();
-  const { scores, loading } = useLeaderboard(leagueId);
+  const { scores, matchNames, loading } = useLeaderboard(leagueId);
   const [busy, setBusy] = useState(false);
   const { loading: cricBusy, syncFromCricApi } = useCricApiMatchScoring();
   const [cricId, setCricId] = useState("");
@@ -205,8 +205,8 @@ export function LeagueClient({
       ) : null}
       {loading ? <p className="text-sm text-neutral-500">Loading scores…</p> : null}
       <Leaderboard scores={scores} teams={teams} ownersByTeamId={ownersByTeamId} todayDate={new Date().toISOString().slice(0, 10)} myTeamId={myTeamId} />
-      <PointsChart scores={scores} teams={teams} />
-      <MatchBreakdown scores={scores} teams={teams} />
+      <PointsChart scores={scores} teams={teams} matchNames={matchNames} />
+      <MatchBreakdown scores={scores} teams={teams} matchNames={matchNames} />
     </div>
   );
 }

--- a/components/league/MatchBreakdown.tsx
+++ b/components/league/MatchBreakdown.tsx
@@ -16,7 +16,7 @@ type PlayerLine = {
   effective_points?: number;
 };
 
-export function MatchBreakdown({ scores, teams }: { scores: ScoreRow[]; teams: LeagueTeamDisplay[] }) {
+export function MatchBreakdown({ scores, teams, matchNames }: { scores: ScoreRow[]; teams: LeagueTeamDisplay[]; matchNames?: Record<string, string> }) {
   const names = new Map(teams.map((t) => [t.id, t.team_name]));
 
   // Group by date, then by match within each date
@@ -45,7 +45,7 @@ export function MatchBreakdown({ scores, teams }: { scores: ScoreRow[]; teams: L
                 <div className="mt-2 space-y-3">
                   {[...matches.entries()].map(([mid, rows]) => (
                     <div key={mid} className="space-y-1">
-                      <p className="text-xs text-neutral-500">Match {mid}</p>
+                      <p className="text-xs text-neutral-500">{matchNames?.[mid] ?? `Match ${mid}`}</p>
                       <ul className="space-y-1 text-sm">
                         {rows.map((r) => (
                           <MatchScoreRow key={r.id} row={r} teamName={names.get(r.scoreboard_team_id) ?? r.scoreboard_team_id} />

--- a/components/league/PointsChart.tsx
+++ b/components/league/PointsChart.tsx
@@ -13,18 +13,19 @@ import {
 import type { LeagueTeamDisplay } from "@/lib/sports/types";
 import type { ScoreRow } from "@/hooks/useLeaderboard";
 
-export function PointsChart({ scores, teams }: { scores: ScoreRow[]; teams: LeagueTeamDisplay[] }) {
+export function PointsChart({ scores, teams, matchNames }: { scores: ScoreRow[]; teams: LeagueTeamDisplay[]; matchNames?: Record<string, string> }) {
   const teamIds = teams.map((t) => t.id);
 
   const data = useMemo(() => {
     const byMatch = new Map<string, Record<string, string | number>>();
     for (const s of scores) {
-      const row = byMatch.get(s.match_id) ?? { match: s.match_id };
+      const label = matchNames?.[s.match_id] ?? s.match_id;
+      const row = byMatch.get(s.match_id) ?? { match: label };
       row[s.scoreboard_team_id] = Number(s.total_points);
       byMatch.set(s.match_id, row);
     }
     return [...byMatch.values()].sort((a, b) => String(a.match).localeCompare(String(b.match)));
-  }, [scores]);
+  }, [scores, matchNames]);
 
   const colors = ["#34d399", "#60a5fa", "#f472b6", "#fbbf24", "#a78bfa", "#f87171"];
 

--- a/components/private-league/TradesList.tsx
+++ b/components/private-league/TradesList.tsx
@@ -35,6 +35,7 @@ interface Props {
   myTeamId: string | null;
   playersById: Record<string, PlayerInfo>;
   teamsById: Record<string, TeamInfo>;
+  ownersByTeamId?: Record<string, string>;
 }
 
 type Section = "incoming" | "outgoing" | "history";
@@ -57,7 +58,7 @@ function timeAgo(dateStr: string): string {
   return `${days}d ago`;
 }
 
-export function TradesList({ trades, myTeamId, playersById, teamsById }: Props) {
+export function TradesList({ trades, myTeamId, playersById, teamsById, ownersByTeamId }: Props) {
   const router = useRouter();
   const [section, setSection] = useState<Section>("incoming");
   const [loading, setLoading] = useState<string | null>(null);
@@ -117,6 +118,7 @@ export function TradesList({ trades, myTeamId, playersById, teamsById }: Props) 
     if (!id) return <span className="text-green-400">Free Agent Pool</span>;
     const t = teamsById[id];
     if (!t) return <span className="text-neutral-500">Unknown team</span>;
+    const owner = ownersByTeamId?.[id];
     return (
       <span className="inline-flex items-center gap-1.5">
         <span
@@ -124,6 +126,7 @@ export function TradesList({ trades, myTeamId, playersById, teamsById }: Props) 
           style={{ backgroundColor: t.team_color ?? "#3B82F6" }}
         />
         <span className="text-neutral-200">{t.team_name}</span>
+        {owner ? <span className="text-neutral-500">· {owner}</span> : null}
       </span>
     );
   };

--- a/hooks/useLeaderboard.ts
+++ b/hooks/useLeaderboard.ts
@@ -19,11 +19,13 @@ export type ScoreRow = {
 export function useLeaderboard(leagueId: string | null) {
   const supabase = useMemo(() => createClient(), []);
   const [scores, setScores] = useState<ScoreRow[]>([]);
+  const [matchNames, setMatchNames] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (!leagueId) {
       setScores([]);
+      setMatchNames({});
       setLoading(false);
       return;
     }
@@ -43,12 +45,27 @@ export function useLeaderboard(leagueId: string | null) {
         total_points: number;
         breakdown: Record<string, unknown>;
       }>;
-      setScores(
-        raw.map((r) => ({
-          ...r,
-          scoreboard_team_id: (r.team_id ?? r.private_team_id) as string,
-        })),
-      );
+      const rows = raw.map((r) => ({
+        ...r,
+        scoreboard_team_id: (r.team_id ?? r.private_team_id) as string,
+      }));
+      setScores(rows);
+
+      // Fetch human-readable match names from cricket_sync_tracker via RPC
+      const matchIds = [...new Set(rows.map((r) => r.match_id))];
+      if (matchIds.length > 0) {
+        const { data: nameRows } = await supabase.rpc("get_match_display_names", {
+          p_match_ids: matchIds,
+        });
+        if (!cancelled && Array.isArray(nameRows)) {
+          const names: Record<string, string> = {};
+          for (const r of nameRows as { match_id: string; display_name: string }[]) {
+            names[r.match_id] = r.display_name;
+          }
+          setMatchNames(names);
+        }
+      }
+
       setLoading(false);
     }
 
@@ -71,5 +88,5 @@ export function useLeaderboard(leagueId: string | null) {
     };
   }, [leagueId, supabase]);
 
-  return { scores, loading };
+  return { scores, matchNames, loading };
 }

--- a/supabase/migrations/015_match_display_names_rpc.sql
+++ b/supabase/migrations/015_match_display_names_rpc.sql
@@ -1,0 +1,23 @@
+-- RPC to expose match display names from cricket_sync_tracker (which has strict RLS).
+-- Returns "Team1 vs Team2" for each match_id, falling back to the raw match_id.
+
+CREATE OR REPLACE FUNCTION get_match_display_names(p_match_ids TEXT[])
+RETURNS TABLE(match_id TEXT, display_name TEXT)
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    cst.match_id,
+    CASE
+      WHEN cst.teams IS NOT NULL
+        AND array_length(cst.teams, 1) >= 2
+        AND cst.teams[1] IS NOT NULL
+        AND cst.teams[2] IS NOT NULL
+        THEN cst.teams[1] || ' vs ' || cst.teams[2]
+      ELSE cst.match_id
+    END AS display_name
+  FROM cricket_sync_tracker cst
+  WHERE cst.match_id = ANY(p_match_ids);
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_match_display_names(TEXT[]) TO authenticated;


### PR DESCRIPTION
## What

Two display improvements on the private league page:

### 1. Leaderboard: match UUIDs → readable names
The "Points by Match" chart x-axis and "Match Breakdown" section were showing raw `match_id` UUIDs (e.g. `2d6c0b86-76c0-4795-...`). Now shows **"Team1 vs Team2"** (e.g. "MI vs CSK").

- New Supabase RPC `get_match_display_names` (`SECURITY DEFINER`) reads `cricket_sync_tracker.teams[]` — bypasses its strict RLS safely
- `useLeaderboard` hook fetches display names after loading scores
- `PointsChart` and `MatchBreakdown` consume the mapping

### 2. Trade History: show team owner names
The History tab in trades showed team names but not who owns them. Now shows **"Punjab Kings · Varad"**.

- `TradesList` accepts new `ownersByTeamId` prop
- Wired from existing server-side mapping in `page.tsx`

## Files changed
| File | Change |
|------|--------|
| `supabase/migrations/015_match_display_names_rpc.sql` | New RPC with NULL-safe concat + GRANT |
| `hooks/useLeaderboard.ts` | Fetch + expose `matchNames` |
| `components/league/PointsChart.tsx` | Use display names on x-axis |
| `components/league/MatchBreakdown.tsx` | Use display names in headers |
| `components/league/LeagueClient.tsx` | Pass `matchNames` through |
| `components/private-league/TradesList.tsx` | Accept + render owner names |
| `app/(app)/league/private/[leagueId]/page.tsx` | Pass `ownersByTeamId` to TradesList |

## Deploy note
Run migration `015_match_display_names_rpc.sql` on Supabase before deploying.