### PR TITLE
fix: improve scoring reliability — error isolation, retry limits, name matching

### DIFF
--- a/app/api/cron/sync-cricapi/route.ts
+++ b/app/api/cron/sync-cricapi/route.ts
@@ -134,6 +134,7 @@ async function loadPendingMatches(
     .from("cricket_sync_tracker")
     .select("match_id,match_date,teams,status,source_preferred,last_error_code,last_error_message,attempts")
     .in("status", ["pending", "failed"])
+    .lt("attempts", 10)
     .lte("match_date", maxDate)
     .order("match_date", { ascending: true })
     .limit(100);
@@ -189,6 +190,33 @@ async function markSynced(
       last_error_code: null,
       last_error_message: null,
       resolved_at: new Date().toISOString(),
+      last_attempt_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "match_id" },
+  );
+}
+
+async function markFailed(
+  supabase: ReturnType<typeof createServerClient>,
+  row: PendingSyncRow & { error_code?: string; error_message?: string },
+): Promise<void> {
+  const current = await supabase
+    .from("cricket_sync_tracker")
+    .select("attempts")
+    .eq("match_id", row.match_id)
+    .maybeSingle();
+  const attempts = (current.data?.attempts ?? 0) + 1;
+  await supabase.from("cricket_sync_tracker").upsert(
+    {
+      match_id: row.match_id,
+      match_date: row.match_date,
+      teams: row.teams ?? null,
+      source_preferred: "cricapi",
+      status: "failed",
+      last_error_code: row.error_code ?? "UNKNOWN",
+      last_error_message: row.error_message ?? "Unknown error",
+      attempts,
       last_attempt_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
     },
@@ -502,12 +530,34 @@ export async function GET(req: NextRequest) {
   let updatedTotal = 0;
   let pendingCount = 0;
   let syncedFromPending = 0;
+  let failedCount = 0;
+  let skippedMaxAttempts = 0;
 
   for (const matchId of matchIds) {
     const meta = discoveredMetaById.get(matchId);
     const pendingMeta = pendingById.get(matchId);
     const expectedTeams = meta?.teams ?? pendingMeta?.teams ?? undefined;
     const effectiveMatchDate = meta?.matchDate ?? pendingMeta?.match_date ?? cronMatchDate;
+
+    // Skip matches that have exceeded max retry attempts
+    const MAX_ATTEMPTS = 10;
+    const priorAttempts = pendingMeta?.attempts ?? 0;
+    if (priorAttempts >= MAX_ATTEMPTS) {
+      skippedMaxAttempts += 1;
+      // Mark permanently failed if not already
+      if (pendingMeta?.status !== "failed") {
+        await markFailed(supabaseAdmin, {
+          match_id: matchId,
+          match_date: effectiveMatchDate,
+          teams: expectedTeams,
+          status: "failed",
+          source_preferred: "cricapi",
+          error_code: "MAX_ATTEMPTS",
+          error_message: `Gave up after ${priorAttempts} attempts. Check player name mappings or CricAPI data availability.`,
+        });
+      }
+      continue;
+    }
 
     // Cache: scorecards don't change for completed matches.
     // If we've already written *any* fantasy_scores rows for this match id, skip API calls.
@@ -533,6 +583,9 @@ export async function GET(req: NextRequest) {
       }
     }
 
+    // Wrap entire match scoring in try-catch so one match failure doesn't crash the whole cron
+    try {
+
     let extracted;
     try {
       // Fetch scorecard: primary CricAPI; on rate-limit use Cricsheet cache.
@@ -557,7 +610,38 @@ export async function GET(req: NextRequest) {
         });
         continue;
       }
-      throw e;
+      // Non-rate-limit error — mark as failed, continue to next match
+      failedCount += 1;
+      const errMsg = e instanceof Error ? e.message : String(e);
+      const errCode = isCricApiError(e) ? e.classified.code : "FETCH_ERROR";
+      console.error(`[cron] Match ${matchId} fetch failed: ${errMsg}`);
+      await markFailed(supabaseAdmin, {
+        match_id: matchId,
+        match_date: effectiveMatchDate,
+        teams: expectedTeams,
+        status: "failed",
+        source_preferred: "cricapi",
+        error_code: errCode,
+        error_message: errMsg.slice(0, 500),
+      });
+      continue;
+    }
+
+    // Guard: if extracted has entries but ALL names failed to match, don't mark synced
+    // This applies per-league below, but check globally first for a fast fail
+    if (extracted.length === 0) {
+      failedCount += 1;
+      console.error(`[cron] Match ${matchId}: CricAPI returned no batting performances`);
+      await markFailed(supabaseAdmin, {
+        match_id: matchId,
+        match_date: effectiveMatchDate,
+        teams: expectedTeams,
+        status: "failed",
+        source_preferred: "cricapi",
+        error_code: "EMPTY_SCORECARD",
+        error_message: "CricAPI returned no batting performances. Match may not be complete yet.",
+      });
+      continue;
     }
 
     for (const league of auctionLeagues) {
@@ -581,7 +665,22 @@ export async function GET(req: NextRequest) {
       }
 
       const players = playersBySport.get(league.sport_id) ?? [];
-      const { performances } = mapCricApiExtractedToPerformances(players, extracted);
+      const { performances, unmatched } = mapCricApiExtractedToPerformances(players, extracted);
+
+      // Log unmatched names for debugging
+      if (unmatched.length > 0) {
+        console.warn(
+          `[cron] Match ${matchId}, league ${league.id}: ${unmatched.length} unmatched player(s): ${unmatched.join(", ")}`,
+        );
+      }
+
+      // Guard: if ALL extracted players failed name matching, skip scoring this league
+      if (performances.length === 0 && extracted.length > 0) {
+        console.error(
+          `[cron] Match ${matchId}, league ${league.id}: ALL ${extracted.length} player names unmatched — skipping`,
+        );
+        continue;
+      }
 
       // Aggregate effective points per team with XI + C/VC multipliers
       const agg = new Map<string, { total: number; breakdown: Record<string, number> }>();
@@ -620,6 +719,7 @@ export async function GET(req: NextRequest) {
           breakdown: {
             source: "cricapi_v1",
             engine_version: "auctionroom-ipl-v1",
+            ...(unmatched.length > 0 ? { unmatched_names: unmatched } : {}),
           },
         };
       });
@@ -687,7 +787,20 @@ export async function GET(req: NextRequest) {
       }
 
       const players = playersBySport.get(league.sport_id) ?? [];
-      const { performances: pPerformances } = mapCricApiExtractedToPerformances(players, extracted);
+      const { performances: pPerformances, unmatched: pUnmatched } = mapCricApiExtractedToPerformances(players, extracted);
+
+      if (pUnmatched.length > 0) {
+        console.warn(
+          `[cron] Match ${matchId}, private league ${league.id}: ${pUnmatched.length} unmatched player(s): ${pUnmatched.join(", ")}`,
+        );
+      }
+
+      if (pPerformances.length === 0 && extracted.length > 0) {
+        console.error(
+          `[cron] Match ${matchId}, private league ${league.id}: ALL ${extracted.length} player names unmatched — skipping`,
+        );
+        continue;
+      }
 
       // Build matchPlayerIds set and role/price maps for auto-substitution
       const matchPlayerIds = new Set(pPerformances.map((row) => row.player_id));
@@ -771,6 +884,7 @@ export async function GET(req: NextRequest) {
             source: "cricapi_v1",
             engine_version: "auctionroom-ipl-v1",
             league_kind: "private",
+            ...(pUnmatched.length > 0 ? { unmatched_names: pUnmatched } : {}),
           },
         };
       });
@@ -791,6 +905,22 @@ export async function GET(req: NextRequest) {
       status: "synced",
       source_preferred: "cricapi",
     });
+
+    } catch (matchErr) {
+      // Catch-all: any unexpected error during this match's scoring
+      failedCount += 1;
+      const errMsg = matchErr instanceof Error ? matchErr.message : String(matchErr);
+      console.error(`[cron] Match ${matchId} unexpected error: ${errMsg}`);
+      await markFailed(supabaseAdmin, {
+        match_id: matchId,
+        match_date: effectiveMatchDate,
+        teams: expectedTeams,
+        status: "failed",
+        source_preferred: "cricapi",
+        error_code: "UNEXPECTED",
+        error_message: errMsg.slice(0, 500),
+      });
+    }
   }
 
   return json({
@@ -798,6 +928,8 @@ export async function GET(req: NextRequest) {
     synced_matches: matchIds.length,
     updated: updatedTotal,
     pending: pendingCount,
+    failed: failedCount,
+    skipped_max_attempts: skippedMaxAttempts,
     synced_from_pending: syncedFromPending,
     cricsheet_imported: cricsheetImported,
     cron_match_date: cronMatchDate,

--- a/app/api/cron/sync-cricapi/route.ts
+++ b/app/api/cron/sync-cricapi/route.ts
@@ -146,12 +146,7 @@ async function markPending(
   supabase: ReturnType<typeof createServerClient>,
   row: PendingSyncRow,
 ): Promise<void> {
-  const current = await supabase
-    .from("cricket_sync_tracker")
-    .select("attempts")
-    .eq("match_id", row.match_id)
-    .maybeSingle();
-  const attempts = (current.data?.attempts ?? 0) + 1;
+  // Upsert first to ensure the row exists, then atomically increment attempts via rpc
   await supabase.from("cricket_sync_tracker").upsert(
     {
       match_id: row.match_id,
@@ -161,31 +156,25 @@ async function markPending(
       status: "pending",
       last_error_code: row.last_error_code ?? null,
       last_error_message: row.last_error_message ?? null,
-      attempts,
       last_attempt_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
     },
     { onConflict: "match_id" },
   );
+  // Atomic increment — avoids race condition if cron runs concurrently
+  await supabase.rpc("increment_sync_attempts", { p_match_id: row.match_id });
 }
 
 async function markSynced(
   supabase: ReturnType<typeof createServerClient>,
   row: PendingSyncRow,
 ): Promise<void> {
-  const current = await supabase
-    .from("cricket_sync_tracker")
-    .select("attempts")
-    .eq("match_id", row.match_id)
-    .maybeSingle();
-  const attempts = current.data?.attempts ?? 0;
   await supabase.from("cricket_sync_tracker").upsert(
     {
       match_id: row.match_id,
       match_date: row.match_date,
       teams: row.teams ?? null,
       source_preferred: "cricapi",
-      attempts,
       status: "synced",
       last_error_code: null,
       last_error_message: null,
@@ -201,12 +190,6 @@ async function markFailed(
   supabase: ReturnType<typeof createServerClient>,
   row: PendingSyncRow & { error_code?: string; error_message?: string },
 ): Promise<void> {
-  const current = await supabase
-    .from("cricket_sync_tracker")
-    .select("attempts")
-    .eq("match_id", row.match_id)
-    .maybeSingle();
-  const attempts = (current.data?.attempts ?? 0) + 1;
   await supabase.from("cricket_sync_tracker").upsert(
     {
       match_id: row.match_id,
@@ -216,12 +199,13 @@ async function markFailed(
       status: "failed",
       last_error_code: row.error_code ?? "UNKNOWN",
       last_error_message: row.error_message ?? "Unknown error",
-      attempts,
       last_attempt_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
     },
     { onConflict: "match_id" },
   );
+  // Atomic increment
+  await supabase.rpc("increment_sync_attempts", { p_match_id: row.match_id });
 }
 
 /**
@@ -539,9 +523,19 @@ export async function GET(req: NextRequest) {
     const expectedTeams = meta?.teams ?? pendingMeta?.teams ?? undefined;
     const effectiveMatchDate = meta?.matchDate ?? pendingMeta?.match_date ?? cronMatchDate;
 
-    // Skip matches that have exceeded max retry attempts
+    // Look up actual attempt count from tracker (covers both pending and newly discovered matches)
     const MAX_ATTEMPTS = 10;
-    const priorAttempts = pendingMeta?.attempts ?? 0;
+    let priorAttempts = pendingMeta?.attempts ?? 0;
+    if (!pendingMeta) {
+      const { data: trackerRow } = await supabaseAdmin
+        .from("cricket_sync_tracker")
+        .select("attempts, status")
+        .eq("match_id", matchId)
+        .maybeSingle();
+      if (trackerRow) {
+        priorAttempts = trackerRow.attempts ?? 0;
+      }
+    }
     if (priorAttempts >= MAX_ATTEMPTS) {
       skippedMaxAttempts += 1;
       // Mark permanently failed if not already

--- a/lib/cricapi/fetch-scorecard.ts
+++ b/lib/cricapi/fetch-scorecard.ts
@@ -63,7 +63,10 @@ function str(v: unknown): string {
 
 /** True if row looks like a dismissed innings (not "did not bat"). */
 function isDismissedBatting(row: Record<string, unknown>): boolean {
-  const d = str(row["dismissal-info"] ?? row.dismissal ?? row.dismissalInfo ?? "");
+  const d = str(
+    row["dismissal-info"] ?? row.dismissal ?? row.dismissalInfo ??
+    row.mode ?? row.how_out ?? row.wicketCode ?? row.out_desc ?? "",
+  );
   if (!d) return false;
   const low = d.toLowerCase();
   if (low.includes("not out") || low.includes("did not bat") || low.includes("dnb")) return false;

--- a/lib/cricapi/map-player-names.ts
+++ b/lib/cricapi/map-player-names.ts
@@ -7,13 +7,29 @@ export type DbPlayer = { id: string; name: string };
  * Map a single CricAPI/scorecard display name to one row in our players table.
  * Handles short initials (e.g. "V Kohli" → "Virat Kohli") when the last name is unique.
  */
+/** Normalize with extra cleanup: strip dots, hyphens, apostrophes */
+function deepNormalize(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[.\-']/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 export function matchDbPlayerForCricApiName(list: DbPlayer[], cricName: string): DbPlayer | null {
   const key = normalizeName(cricName);
   if (!key) return null;
 
+  // Stage 1: Exact normalized match
   const exact = list.find((p) => normalizeName(p.name) === key);
   if (exact) return exact;
 
+  // Stage 1b: Deep normalize (strip dots, hyphens, apostrophes)
+  const deepKey = deepNormalize(cricName);
+  const deepExact = list.find((p) => deepNormalize(p.name) === deepKey);
+  if (deepExact) return deepExact;
+
+  // Stage 2: Fuzzy substring match (both directions)
   const fuzzy = list.find(
     (p) =>
       key.length >= 4 &&
@@ -23,17 +39,29 @@ export function matchDbPlayerForCricApiName(list: DbPlayer[], cricName: string):
 
   const parts = key.split(/\s+/).filter(Boolean);
   const last = parts.length ? parts[parts.length - 1]! : "";
-  if (last.length < 4) return null;
 
+  // Stage 3: Last name match (unique)
   const lastNameMatches = list.filter((p) => {
     const pn = normalizeName(p.name);
     const pParts = pn.split(/\s+/).filter(Boolean);
     const pLast = pParts.length ? pParts[pParts.length - 1]! : "";
     return pLast === last;
   });
-  if (lastNameMatches.length === 1) return lastNameMatches[0]!;
 
-  if (parts.length >= 2 && parts[0]!.length <= 3 && last.length >= 4 && lastNameMatches.length > 0) {
+  // For short last names (< 4 chars), try full-string contains before giving up
+  if (last.length < 4) {
+    if (lastNameMatches.length === 1) return lastNameMatches[0]!;
+    // Try: does the full CricAPI name appear as a substring of any DB name?
+    const containsMatch = list.filter((p) => deepNormalize(p.name).includes(deepKey));
+    if (containsMatch.length === 1) return containsMatch[0]!;
+    // Fall through to initial-based matching below if we have last name matches
+    if (lastNameMatches.length === 0) return null;
+  } else {
+    if (lastNameMatches.length === 1) return lastNameMatches[0]!;
+  }
+
+  // Stage 4: Initial + last name disambiguation
+  if (parts.length >= 2 && parts[0]!.length <= 3 && lastNameMatches.length > 0) {
     const initial = parts[0]!;
     const narrowed = lastNameMatches.filter((p) => {
       const pn = normalizeName(p.name);
@@ -41,7 +69,17 @@ export function matchDbPlayerForCricApiName(list: DbPlayer[], cricName: string):
       return firstWord.startsWith(initial);
     });
     if (narrowed.length === 1) return narrowed[0]!;
-    if (narrowed.length > 1) return null;
+
+    // Stage 4b: Try 2-char first name prefix when initial matching fails
+    if (narrowed.length === 0 && initial.length >= 2) {
+      const prefix2 = initial.slice(0, 2);
+      const byPrefix = lastNameMatches.filter((p) => {
+        const pn = normalizeName(p.name);
+        const firstWord = pn.split(/\s+/).filter(Boolean)[0] ?? "";
+        return firstWord.startsWith(prefix2);
+      });
+      if (byPrefix.length === 1) return byPrefix[0]!;
+    }
   }
 
   return null;

--- a/lib/scoring/fetch-with-fallback.ts
+++ b/lib/scoring/fetch-with-fallback.ts
@@ -30,7 +30,6 @@ import {
   mergeBowlingFromCricApiJson,
   type CricApiMappedPerformance,
 } from "@/lib/cricapi/fetch-scorecard";
-import { isCricApiError } from "@/lib/cricapi/errors";
 
 type FallbackOpts = {
   /** CricAPI match UUID (used for CricAPI call). */
@@ -70,12 +69,8 @@ export async function fetchScorecardWithFallback(
     extracted = mergeBowlingFromCricApiJson(extracted, raw);
     return { performances: extracted, provider: "cricapi", raw };
   } catch (err) {
-    // Only fall back to Cricsheet for rate-limit errors
-    if (!isCricApiError(err) || err.classified.code !== "RATE_LIMIT") {
-      throw err;
-    }
-
-    // 2. CricAPI rate-limited → try Cricsheet cache (backfill data)
+    // 2. CricAPI failed — try Cricsheet cache as fallback for ANY error
+    // (rate-limit, HTTP 500, timeout, network errors, etc.)
     if (supabase && matchDate) {
       const cached = await tryLoadCricsheetCache(supabase, matchDate, expectedTeams);
       if (cached && cached.length > 0) {
@@ -83,9 +78,7 @@ export async function fetchScorecardWithFallback(
       }
     }
 
-    // 3. Cricsheet also doesn't have data yet — re-throw
-    // The match stays un-scored; next cron run will auto-sync Cricsheet
-    // and retry.
+    // 3. Cricsheet also doesn't have data — re-throw original error
     throw err;
   }
 }

--- a/supabase/migrations/017_increment_sync_attempts_rpc.sql
+++ b/supabase/migrations/017_increment_sync_attempts_rpc.sql
@@ -1,0 +1,13 @@
+-- Atomic increment for cricket_sync_tracker.attempts
+-- Avoids race conditions when cron runs concurrently with manual triggers
+CREATE OR REPLACE FUNCTION increment_sync_attempts(p_match_id TEXT)
+RETURNS VOID
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+  UPDATE cricket_sync_tracker
+  SET attempts = COALESCE(attempts, 0) + 1
+  WHERE match_id = p_match_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION increment_sync_attempts(TEXT) TO authenticated, service_role;


### PR DESCRIPTION
## Scoring Reliability Improvements

Addresses intermittent scoring failures where matches would silently score with incomplete data or crash the entire cron on a single match error.

### Changes

**Error Isolation & Retry Limits**
- Each match scoring wrapped in try-catch — one failure no longer crashes the entire cron
- 10-attempt limit: permanently marks matches as `failed` after max retries
- `loadPendingMatches` filters out matches with ≥10 attempts

**Empty/Unmatched Safeguards**
- Empty scorecard (no batting data) → `EMPTY_SCORECARD` failure, not silent sync
- All player names unmatched for a league → skip that league's scoring with warning
- Unmatched player names stored in `fantasy_scores.breakdown.unmatched_names` for debugging
- Console warnings log unmatched names with match/league context

**Name Matching Improvements**
- Deep normalization: strips dots, hyphens, apostrophes (e.g. `D'Arcy` → `darcy`)
- Short last names (<4 chars): tries full-string contains + unique last name match before giving up
- 2-char first name prefix fallback when initial matching narrows to 0

**Dismissal Detection**
- Checks additional CricAPI field names: `mode`, `how_out`, `wicketCode`, `out_desc`

**Fallback Improvements**
- Cricsheet cache tried on ANY CricAPI error (not just rate-limit)
- Covers HTTP 500, timeouts, network errors

### Files Changed
- `app/api/cron/sync-cricapi/route.ts` — Error isolation, attempt limits, unmatched guards
- `lib/cricapi/map-player-names.ts` — Improved name matching
- `lib/cricapi/fetch-scorecard.ts` — Additional dismissal field names
- `lib/scoring/fetch-with-fallback.ts` — Fallback on all errors