### PR TITLE
feat: leaderboard shows last match points, chart sorted by date

### DIFF
--- a/components/league/Leaderboard.tsx
+++ b/components/league/Leaderboard.tsx
@@ -1,34 +1,62 @@
 "use client";
 
 import type { LeagueTeamDisplay } from "@/lib/sports/types";
-import type { ScoreRow } from "@/hooks/useLeaderboard";
+import type { ScoreRow, MatchMeta } from "@/hooks/useLeaderboard";
 
 export function Leaderboard({
   scores,
   teams,
   ownersByTeamId,
-  todayDate,
+  matchMeta,
   myTeamId,
 }: {
   scores: ScoreRow[];
   teams: LeagueTeamDisplay[];
   /** Optional: show owner display name separate from franchise/team name */
   ownersByTeamId?: Record<string, string>;
-  /** ISO date string (YYYY-MM-DD) to compute today's points */
-  todayDate?: string;
+  /** Match metadata for finding last match info */
+  matchMeta?: Record<string, MatchMeta>;
   /** Highlight the user's team row */
   myTeamId?: string;
 }) {
   const names = new Map(teams.map((t) => [t.id, t.team_name]));
   const totals = new Map<string, number>(teams.map((t) => [t.id, 0]));
-  const todayPts = new Map<string, number>(teams.map((t) => [t.id, 0]));
+
+  // Find the most recent match by date
+  let lastMatchDate = "";
+  let lastMatchIds: string[] = [];
+  for (const s of scores) {
+    const date = matchMeta?.[s.match_id]?.match_date || s.match_date;
+    if (date > lastMatchDate) {
+      lastMatchDate = date;
+      lastMatchIds = [s.match_id];
+    } else if (date === lastMatchDate && !lastMatchIds.includes(s.match_id)) {
+      lastMatchIds.push(s.match_id);
+    }
+  }
+  const lastMatchIdSet = new Set(lastMatchIds);
+
+  // Compute last match points per team
+  const lastMatchPts = new Map<string, number>(teams.map((t) => [t.id, 0]));
   for (const s of scores) {
     totals.set(s.scoreboard_team_id, (totals.get(s.scoreboard_team_id) ?? 0) + Number(s.total_points));
-    if (todayDate && s.match_date === todayDate) {
-      todayPts.set(s.scoreboard_team_id, (todayPts.get(s.scoreboard_team_id) ?? 0) + Number(s.total_points));
+    if (lastMatchIdSet.has(s.match_id)) {
+      lastMatchPts.set(s.scoreboard_team_id, (lastMatchPts.get(s.scoreboard_team_id) ?? 0) + Number(s.total_points));
     }
   }
   const rows = [...totals.entries()].sort((a, b) => b[1] - a[1]);
+
+  // Build last match label (e.g. "Apr 9 · CSK vs MI")
+  const lastMatchLabel = lastMatchIds.length > 0
+    ? lastMatchIds.map((id) => {
+        const meta = matchMeta?.[id];
+        return meta?.display_name ?? id;
+      }).join(", ")
+    : "";
+  const lastDateFormatted = lastMatchDate
+    ? new Date(lastMatchDate + "T00:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" })
+    : "";
+  const hasLastMatch = lastMatchIds.length > 0;
 
   return (
     <div className="rounded-xl border border-neutral-800 bg-neutral-950/60 p-4">
@@ -43,7 +71,16 @@ export function Leaderboard({
                 <th className="pb-2 pr-2 text-left font-medium">#</th>
                 <th className="pb-2 pr-2 text-left font-medium">Team</th>
                 <th className="pb-2 pr-2 text-left font-medium">Owner</th>
-                {todayDate ? <th className="pb-2 pl-2 text-right font-medium">Today</th> : null}
+                {hasLastMatch ? (
+                  <th className="pb-2 pl-2 text-right font-medium">
+                    <div className="flex flex-col items-end">
+                      <span>Last Match</span>
+                      <span className="text-[10px] text-neutral-600 font-normal max-w-[8rem] truncate" title={`${lastDateFormatted} · ${lastMatchLabel}`}>
+                        {lastDateFormatted} · {lastMatchLabel}
+                      </span>
+                    </div>
+                  </th>
+                ) : null}
                 <th className="pb-2 pl-2 text-right font-medium">Total</th>
               </tr>
             </thead>
@@ -56,8 +93,8 @@ export function Leaderboard({
                   <td className="py-2 pr-2 text-neutral-500">{i + 1}</td>
                   <td className="py-2 pr-2 text-neutral-300 truncate max-w-[10rem]">{names.get(teamId) ?? teamId}</td>
                   <td className="py-2 pr-2 text-neutral-500">{ownersByTeamId?.[teamId] ?? "—"}</td>
-                  {todayDate ? (
-                    <td className="py-2 pl-2 text-right font-mono text-neutral-300">{(todayPts.get(teamId) ?? 0).toFixed(1)}</td>
+                  {hasLastMatch ? (
+                    <td className="py-2 pl-2 text-right font-mono text-neutral-300">{(lastMatchPts.get(teamId) ?? 0).toFixed(1)}</td>
                   ) : null}
                   <td className="py-2 pl-2 text-right font-mono text-blue-200">{pts.toFixed(1)}</td>
                 </tr>

--- a/components/league/LeagueClient.tsx
+++ b/components/league/LeagueClient.tsx
@@ -38,7 +38,7 @@ export function LeagueClient({
   myTeamId?: string;
 }) {
   const router = useRouter();
-  const { scores, matchNames, loading } = useLeaderboard(leagueId);
+  const { scores, matchNames, matchMeta, loading } = useLeaderboard(leagueId);
   const [busy, setBusy] = useState(false);
   const { loading: cricBusy, syncFromCricApi } = useCricApiMatchScoring();
   const [cricId, setCricId] = useState("");
@@ -204,8 +204,8 @@ export function LeagueClient({
         </div>
       ) : null}
       {loading ? <p className="text-sm text-neutral-500">Loading scores…</p> : null}
-      <Leaderboard scores={scores} teams={teams} ownersByTeamId={ownersByTeamId} todayDate={new Date().toISOString().slice(0, 10)} myTeamId={myTeamId} />
-      <PointsChart scores={scores} teams={teams} matchNames={matchNames} />
+      <Leaderboard scores={scores} teams={teams} ownersByTeamId={ownersByTeamId} matchMeta={matchMeta} myTeamId={myTeamId} />
+      <PointsChart scores={scores} teams={teams} matchNames={matchNames} matchMeta={matchMeta} />
       <MatchBreakdown scores={scores} teams={teams} matchNames={matchNames} />
     </div>
   );

--- a/components/league/PointsChart.tsx
+++ b/components/league/PointsChart.tsx
@@ -11,21 +11,48 @@ import {
   YAxis,
 } from "recharts";
 import type { LeagueTeamDisplay } from "@/lib/sports/types";
-import type { ScoreRow } from "@/hooks/useLeaderboard";
+import type { ScoreRow, MatchMeta } from "@/hooks/useLeaderboard";
 
-export function PointsChart({ scores, teams, matchNames }: { scores: ScoreRow[]; teams: LeagueTeamDisplay[]; matchNames?: Record<string, string> }) {
+/** Format YYYY-MM-DD → "Mar 22" style */
+function formatShortDate(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00");
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+/** Shorten team name: "Royal Challengers Bengaluru" → "RCB"-style abbreviation or first word */
+function shortenTeam(name: string): string {
+  const words = name.split(/\s+/);
+  if (words.length <= 1) return name;
+  // Use initials for multi-word names (e.g. "Mumbai Indians" → "MI")
+  return words.map((w) => w[0]?.toUpperCase() ?? "").join("");
+}
+
+export function PointsChart({ scores, teams, matchNames, matchMeta }: { scores: ScoreRow[]; teams: LeagueTeamDisplay[]; matchNames?: Record<string, string>; matchMeta?: Record<string, MatchMeta> }) {
   const teamIds = teams.map((t) => t.id);
 
   const data = useMemo(() => {
-    const byMatch = new Map<string, Record<string, string | number>>();
+    // Group scores by match_id, include date for sorting
+    const byMatch = new Map<string, { row: Record<string, string | number>; date: string }>();
     for (const s of scores) {
-      const label = matchNames?.[s.match_id] ?? s.match_id;
-      const row = byMatch.get(s.match_id) ?? { match: label };
-      row[s.scoreboard_team_id] = Number(s.total_points);
-      byMatch.set(s.match_id, row);
+      const meta = matchMeta?.[s.match_id];
+      const date = meta?.match_date || s.match_date;
+      const displayName = meta?.display_name ?? matchNames?.[s.match_id] ?? s.match_id;
+
+      // Build x-axis label: "Apr 9 · MI vs CSK"
+      const shortTeams = displayName.includes(" vs ")
+        ? displayName.split(" vs ").map((t) => shortenTeam(t.trim())).join(" vs ")
+        : displayName;
+      const label = date ? `${formatShortDate(date)} · ${shortTeams}` : shortTeams;
+
+      const entry = byMatch.get(s.match_id) ?? { row: { match: label }, date };
+      entry.row[s.scoreboard_team_id] = Number(s.total_points);
+      byMatch.set(s.match_id, entry);
     }
-    return [...byMatch.values()].sort((a, b) => String(a.match).localeCompare(String(b.match)));
-  }, [scores, matchNames]);
+    // Sort chronologically by match_date, then by label for same-day matches
+    return [...byMatch.values()]
+      .sort((a, b) => a.date.localeCompare(b.date) || String(a.row.match).localeCompare(String(b.row.match)))
+      .map((e) => e.row);
+  }, [scores, matchNames, matchMeta]);
 
   const colors = ["#34d399", "#60a5fa", "#f472b6", "#fbbf24", "#a78bfa", "#f87171"];
 
@@ -34,14 +61,26 @@ export function PointsChart({ scores, teams, matchNames }: { scores: ScoreRow[];
   }
 
   return (
-    <div className="h-72 w-full rounded-xl border border-neutral-800 bg-neutral-950/60 p-4">
+    <div className="h-80 w-full rounded-xl border border-neutral-800 bg-neutral-950/60 p-4">
       <h3 className="text-sm font-medium uppercase tracking-wide text-neutral-500">Points by match</h3>
       <ResponsiveContainer width="100%" height="90%">
         <LineChart data={data}>
           <CartesianGrid strokeDasharray="3 3" stroke="#333" />
-          <XAxis dataKey="match" stroke="#888" fontSize={11} />
+          <XAxis
+            dataKey="match"
+            stroke="#888"
+            fontSize={10}
+            interval={0}
+            angle={-35}
+            textAnchor="end"
+            height={60}
+            tick={{ fill: "#888" }}
+          />
           <YAxis stroke="#888" fontSize={11} />
-          <Tooltip contentStyle={{ background: "#0a0a0b", border: "1px solid #333" }} />
+          <Tooltip
+            contentStyle={{ background: "#0a0a0b", border: "1px solid #333", fontSize: 12 }}
+            labelStyle={{ color: "#ccc", marginBottom: 4 }}
+          />
           {teamIds.map((id, i) => (
             <Line
               key={id}

--- a/hooks/useLeaderboard.ts
+++ b/hooks/useLeaderboard.ts
@@ -16,16 +16,23 @@ export type ScoreRow = {
   breakdown: Record<string, unknown>;
 };
 
+export type MatchMeta = {
+  display_name: string;
+  match_date: string;
+};
+
 export function useLeaderboard(leagueId: string | null) {
   const supabase = useMemo(() => createClient(), []);
   const [scores, setScores] = useState<ScoreRow[]>([]);
   const [matchNames, setMatchNames] = useState<Record<string, string>>({});
+  const [matchMeta, setMatchMeta] = useState<Record<string, MatchMeta>>({});
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (!leagueId) {
       setScores([]);
       setMatchNames({});
+      setMatchMeta({});
       setLoading(false);
       return;
     }
@@ -51,7 +58,7 @@ export function useLeaderboard(leagueId: string | null) {
       }));
       setScores(rows);
 
-      // Fetch human-readable match names from cricket_sync_tracker via RPC
+      // Fetch human-readable match names + dates from cricket_sync_tracker via RPC
       const matchIds = [...new Set(rows.map((r) => r.match_id))];
       if (matchIds.length > 0) {
         const { data: nameRows } = await supabase.rpc("get_match_display_names", {
@@ -59,10 +66,16 @@ export function useLeaderboard(leagueId: string | null) {
         });
         if (!cancelled && Array.isArray(nameRows)) {
           const names: Record<string, string> = {};
-          for (const r of nameRows as { match_id: string; display_name: string }[]) {
+          const meta: Record<string, MatchMeta> = {};
+          for (const r of nameRows as { match_id: string; display_name: string; match_date?: string }[]) {
             names[r.match_id] = r.display_name;
+            meta[r.match_id] = {
+              display_name: r.display_name,
+              match_date: r.match_date ?? "",
+            };
           }
           setMatchNames(names);
+          setMatchMeta(meta);
         }
       }
 
@@ -88,5 +101,5 @@ export function useLeaderboard(leagueId: string | null) {
     };
   }, [leagueId, supabase]);
 
-  return { scores, matchNames, loading };
+  return { scores, matchNames, matchMeta, loading };
 }

--- a/supabase/migrations/018_match_display_names_with_date.sql
+++ b/supabase/migrations/018_match_display_names_with_date.sql
@@ -1,7 +1,4 @@
--- RPC to expose match display names from cricket_sync_tracker (which has strict RLS).
--- Returns "Team1 vs Team2" for each match_id, falling back to the raw match_id.
--- Also returns match_date for chronological sorting.
-
+-- Update get_match_display_names to also return match_date for chronological sorting.
 CREATE OR REPLACE FUNCTION get_match_display_names(p_match_ids TEXT[])
 RETURNS TABLE(match_id TEXT, display_name TEXT, match_date TEXT)
 LANGUAGE sql STABLE SECURITY DEFINER
@@ -21,5 +18,3 @@ AS $$
   FROM cricket_sync_tracker cst
   WHERE cst.match_id = ANY(p_match_ids);
 $$;
-
-GRANT EXECUTE ON FUNCTION public.get_match_display_names(TEXT[]) TO authenticated;


### PR DESCRIPTION
## Changes

### Leaderboard
- **'Today' → 'Last Match'**: Column now shows points from the most recent scored match instead of today (which was always 0.0 unless a match happened today)
- Header shows date + teams: e.g. `Apr 9 · CSK vs MI`
- Long names truncated with hover tooltip

### Points by Match Chart
- **Chronological sorting**: X-axis now sorted by `match_date` (was alphabetical by label — random-looking order)
- **Better labels**: `Apr 9 · MI vs CSK` format (date + abbreviated team names)
- Angled labels at -35° to prevent overlap on the x-axis
- Slightly taller chart for readability

### Data Layer
- `useLeaderboard` hook now returns `matchMeta` (`display_name` + `match_date` per match)
- Updated `get_match_display_names` RPC to also return `match_date`
- Migration 018 applies the updated RPC

### Files Changed
- `components/league/Leaderboard.tsx` — Last match logic
- `components/league/PointsChart.tsx` — Date sorting + label formatting
- `components/league/LeagueClient.tsx` — Pass matchMeta
- `hooks/useLeaderboard.ts` — MatchMeta type + state
- `supabase/migrations/018_match_display_names_with_date.sql` — Updated RPC