### PR TITLE
feat: change FA window reset to Saturday 8:30 AM PT, improve UX

### DIFF
--- a/components/private-league/FreeAgentsList.tsx
+++ b/components/private-league/FreeAgentsList.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { PlayerMeta } from "@/components/player/PlayerMeta";
-import { isFreeAgentWindowUsed } from "@/lib/free-agent-window";
+import { isFreeAgentWindowUsed, getNextResetTime } from "@/lib/free-agent-window";
 
 export interface FreeAgent {
   id: string;
@@ -181,10 +181,15 @@ export function FreeAgentsList({
         <div className="rounded-xl border border-white/10 bg-neutral-950/50 p-4">
           {!windowOpen ? (
             windowUsed ? (
-              <div className="flex items-center gap-3">
-                <span className="text-sm text-neutral-400">
-                  ✓ Free agent window used this week. Resets Saturday at midnight PT.
-                </span>
+              <div className="space-y-1.5">
+                <p className="text-sm text-neutral-300">
+                  ✓ Free agent window used this week.
+                </p>
+                <p className="text-xs text-neutral-500">
+                  Your next window opens <span className="text-neutral-400 font-medium">{getNextResetTime().pt} PT</span>
+                  {" · "}<span className="text-neutral-400">{getNextResetTime().ist} IST</span>
+                  {" · "}<span className="text-neutral-400">{getNextResetTime().et} ET</span>
+                </p>
               </div>
             ) : (
               <div className="flex items-center justify-between gap-3">
@@ -254,12 +259,25 @@ export function FreeAgentsList({
                   disabled={committing || staged.length === 0}
                   className="cursor-pointer rounded-lg bg-green-600 px-4 py-1.5 text-xs font-semibold text-white transition hover:bg-green-500 disabled:cursor-not-allowed disabled:opacity-50"
                 >
-                  {committing ? "Saving…" : "Confirm Changes"}
+                  {committing ? "Saving…" : "Close Window & Save Changes"}
                 </button>
               </div>
 
-              <p className="text-[11px] text-amber-400/80">
-                ⚠ Changes are not saved until you click Confirm. If you leave this page, all staged changes will be lost.
+              {staged.length > 0 ? (
+                <div className="rounded-lg border border-amber-500/20 bg-amber-950/20 px-3 py-2 space-y-1">
+                  <p className="text-[11px] text-amber-300/90 font-medium">
+                    ⚠ Once you save, your free agent window will be used for this week.
+                  </p>
+                  <p className="text-[11px] text-amber-400/70">
+                    Next window opens: <span className="font-medium text-amber-300/80">{getNextResetTime().pt} PT</span>
+                    {" · "}{getNextResetTime().ist} IST
+                    {" · "}{getNextResetTime().et} ET
+                  </p>
+                </div>
+              ) : null}
+
+              <p className="text-[11px] text-neutral-500">
+                Changes are not saved until you click &quot;Close Window &amp; Save Changes&quot;. If you leave this page, all staged changes will be lost.
               </p>
             </div>
           )}

--- a/lib/free-agent-window.ts
+++ b/lib/free-agent-window.ts
@@ -1,9 +1,9 @@
 /**
- * Returns the most recent Saturday at midnight Pacific Time as a Date.
+ * Returns the most recent Saturday at 8:30 AM Pacific Time as a Date.
  * The free agent window resets at this boundary each week.
  */
 export function getFreeAgentWeekStart(now: Date = new Date()): Date {
-  // Convert to Pacific Time using Intl to get the correct local day
+  // Convert to Pacific Time using Intl to get the correct local day/time
   const ptStr = now.toLocaleString("en-US", { timeZone: "America/Los_Angeles" });
   const ptDate = new Date(ptStr);
   const dow = ptDate.getDay(); // 0=Sun, 6=Sat
@@ -11,32 +11,54 @@ export function getFreeAgentWeekStart(now: Date = new Date()): Date {
   // Days since last Saturday: Sun=1, Mon=2, ..., Fri=6, Sat=0
   const daysSinceSat = (dow + 1) % 7;
 
-  // Build a Date for that Saturday midnight in PT
+  // Build the Saturday date in PT
   const satPt = new Date(ptDate);
   satPt.setDate(satPt.getDate() - daysSinceSat);
-  satPt.setHours(0, 0, 0, 0);
+  satPt.setHours(8, 30, 0, 0);
 
-  // Convert back to UTC by formatting as a PT midnight string and parsing
-  const iso = satPt.toLocaleDateString("en-CA", { timeZone: "America/Los_Angeles" }); // YYYY-MM-DD
-  // Saturday midnight PT → UTC: PT is UTC-7 (PDT) or UTC-8 (PST)
-  // Use a reliable approach: construct the date in PT and get its UTC equivalent
-  const utc = new Date(`${iso}T00:00:00-07:00`);
-  // Adjust for PST vs PDT by checking if the original date is in PST
-  const janOffset = new Date(now.getFullYear(), 0, 1).getTimezoneOffset();
-  const nowOffset = new Date(
-    now.toLocaleString("en-US", { timeZone: "America/Los_Angeles" }),
-  ).getTimezoneOffset();
-  // If we can't reliably detect, use the Intl API
+  // If we're on Saturday but before 8:30 AM PT, use the previous Saturday
+  if (daysSinceSat === 0 && ptDate < satPt) {
+    satPt.setDate(satPt.getDate() - 7);
+  }
+
+  // Get PT offset (PST vs PDT)
   const formatter = new Intl.DateTimeFormat("en-US", {
     timeZone: "America/Los_Angeles",
     timeZoneName: "short",
   });
   const parts = formatter.formatToParts(now);
   const tzName = parts.find((p) => p.type === "timeZoneName")?.value ?? "";
-  const isPST = tzName === "PST";
-  const offset = isPST ? "-08:00" : "-07:00";
+  const offset = tzName === "PST" ? "-08:00" : "-07:00";
 
-  return new Date(`${iso}T00:00:00${offset}`);
+  const iso = satPt.toLocaleDateString("en-CA", { timeZone: "America/Los_Angeles" }); // YYYY-MM-DD
+  return new Date(`${iso}T08:30:00${offset}`);
+}
+
+/**
+ * Compute the next Saturday 8:30 AM PT reset time, formatted in multiple timezones.
+ */
+export function getNextResetTime(now: Date = new Date()): { pt: string; ist: string; et: string; raw: Date } {
+  const weekStart = getFreeAgentWeekStart(now);
+  // Next reset is weekStart + 7 days
+  const next = new Date(weekStart.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+  const fmt = (tz: string) =>
+    next.toLocaleString("en-US", {
+      timeZone: tz,
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    });
+
+  return {
+    pt: fmt("America/Los_Angeles"),
+    ist: fmt("Asia/Kolkata"),
+    et: fmt("America/New_York"),
+    raw: next,
+  };
 }
 
 /**

--- a/supabase/migrations/019_fa_window_reset_830am.sql
+++ b/supabase/migrations/019_fa_window_reset_830am.sql
@@ -1,13 +1,10 @@
--- Weekly free agent window: teams can open one free agent window per week.
--- Changes are staged client-side and committed atomically via RPC.
--- The weekly window resets every Saturday at 12:00 AM Pacific Time.
+-- Change free agent window reset time from Saturday midnight PT to Saturday 8:30 AM PT.
+-- Also reset everyone's fa_window_used_at so all teams get a fresh window.
 
-ALTER TABLE private_league_teams
-  ADD COLUMN IF NOT EXISTS fa_window_used_at TIMESTAMPTZ;
+-- Reset all teams' free agent window
+UPDATE private_league_teams SET fa_window_used_at = NULL;
 
--- Atomically commit a batch of free agent swaps for a team's weekly window.
--- p_swaps: JSONB array of { "drop": "player_uuid", "add": "player_uuid" } objects.
--- Items with drop=null are pure adds (squad not full); items with add=null are pure drops.
+-- Update the RPC with new 8:30 AM PT reset time
 CREATE OR REPLACE FUNCTION commit_free_agent_window(
   p_team_id UUID,
   p_league_id UUID,
@@ -30,7 +27,6 @@ DECLARE
   v_max_squad INT := 15;
 BEGIN
   -- Compute the most recent Saturday 8:30 AM Pacific Time.
-  -- DOW: 0=Sun,1=Mon,...,6=Sat. We want the last Saturday (DOW=6).
   v_week_start := (
     date_trunc('day',
       (NOW() AT TIME ZONE 'America/Los_Angeles')
@@ -93,7 +89,6 @@ BEGIN
         RETURN jsonb_build_object('error', 'Squad would exceed maximum size (15)');
       END IF;
 
-      -- Check player not already on any team in the league
       SELECT EXISTS (
         SELECT 1 FROM private_league_teams plt
         WHERE plt.league_id = p_league_id
@@ -115,7 +110,6 @@ BEGIN
   -- Apply the final squad and mark window as used
   UPDATE private_league_teams SET
     squad_player_ids = v_squad,
-    -- Remove dropped players from starting XI, captain, and vice-captain
     starting_xi_player_ids = (
       SELECT COALESCE(array_agg(pid), '{}')
       FROM unnest(starting_xi_player_ids) AS pid
@@ -129,5 +123,3 @@ BEGIN
   RETURN jsonb_build_object('success', true, 'squad_size', array_length(v_squad, 1));
 END;
 $$;
-
-GRANT EXECUTE ON FUNCTION public.commit_free_agent_window(UUID, UUID, UUID, JSONB) TO authenticated;


### PR DESCRIPTION
## Changes

### Reset Time
- Changed from **Saturday midnight PT** → **Saturday 8:30 AM PT**
- Updated in both PostgreSQL RPC and client-side JS utility

### One-Time Reset
- Migration 019 sets `fa_window_used_at = NULL` for all teams — everyone gets a fresh window immediately

### UX Improvements
- **When window is used**: Shows next reset time in 3 timezones:
  > ✓ Free agent window used this week.
  > Next window opens **Sat, Apr 18, 8:30 AM PT** · Sat, Apr 18, 9:00 PM IST · Sat, Apr 18, 11:30 AM ET
- **Before confirming changes**: Amber warning box clearly states:
  > ⚠ Once you save, your free agent window will be used for this week.
  > Next window opens: **Sat, Apr 18, 8:30 AM PT** · 9:00 PM IST · 11:30 AM ET
- Button renamed: `Confirm Changes` → `Close Window & Save Changes`

### Files
- `lib/free-agent-window.ts` — Updated `getFreeAgentWeekStart()` to 8:30 AM, added `getNextResetTime()`
- `components/private-league/FreeAgentsList.tsx` — UX messaging with multi-timezone display
- `supabase/migrations/016_free_agent_window.sql` — Source-of-truth RPC updated
- `supabase/migrations/019_fa_window_reset_830am.sql` — Applies reset + updated RPC