### PR TITLE
feat: cron player_lines + Levenshtein auto-correction for name mismatches

### DIFF
--- a/app/api/cron/sync-cricapi/route.ts
+++ b/app/api/cron/sync-cricapi/route.ts
@@ -490,12 +490,12 @@ export async function GET(req: NextRequest) {
   const auctionLeagues = (leagues ?? []).filter((l: ActiveLeagueRow) => l.league_kind === "auction");
   const privateLeagues = (leagues ?? []).filter((l: ActiveLeagueRow) => l.league_kind === "private");
 
-  // Preload players for each sport once.
+  // Preload players for each sport once (including name_aliases for fuzzy matching).
   const sportIds = [...new Set((leagues ?? []).map((l: ActiveLeagueRow) => l.sport_id))];
-  const playersBySport = new Map<string, { id: string; name: string }[]>();
+  const playersBySport = new Map<string, { id: string; name: string; name_aliases?: string[] | null }[]>();
   await Promise.all(
     sportIds.map(async (sportId) => {
-      const { data, error } = await supabaseAdmin.from("players").select("id, name").eq("sport_id", sportId);
+      const { data, error } = await supabaseAdmin.from("players").select("id, name, name_aliases").eq("sport_id", sportId);
       if (!error) playersBySport.set(sportId, data ?? []);
     }),
   );
@@ -659,7 +659,18 @@ export async function GET(req: NextRequest) {
       }
 
       const players = playersBySport.get(league.sport_id) ?? [];
-      const { performances, unmatched } = mapCricApiExtractedToPerformances(players, extracted);
+      const { performances, unmatched, autoCorrections } = mapCricApiExtractedToPerformances(players, extracted);
+
+      // Auto-save CricAPI name as alias for fuzzy-matched players
+      if (autoCorrections.length > 0) {
+        for (const ac of autoCorrections) {
+          console.log(`[auto-alias] "${ac.cricapi_name}" → "${ac.db_name}" (${ac.method})`);
+          await supabaseAdmin.rpc("add_player_name_alias", {
+            p_player_id: ac.player_id,
+            p_alias: ac.cricapi_name,
+          });
+        }
+      }
 
       // Log unmatched names for debugging
       if (unmatched.length > 0) {
@@ -797,7 +808,17 @@ export async function GET(req: NextRequest) {
       }
 
       const players = playersBySport.get(league.sport_id) ?? [];
-      const { performances: pPerformances, unmatched: pUnmatched } = mapCricApiExtractedToPerformances(players, extracted);
+      const { performances: pPerformances, unmatched: pUnmatched, autoCorrections: pAutoCorrections } = mapCricApiExtractedToPerformances(players, extracted);
+
+      if (pAutoCorrections.length > 0) {
+        for (const ac of pAutoCorrections) {
+          console.log(`[auto-alias] "${ac.cricapi_name}" → "${ac.db_name}" (${ac.method})`);
+          await supabaseAdmin.rpc("add_player_name_alias", {
+            p_player_id: ac.player_id,
+            p_alias: ac.cricapi_name,
+          });
+        }
+      }
 
       if (pUnmatched.length > 0) {
         console.warn(

--- a/app/api/cron/sync-cricapi/route.ts
+++ b/app/api/cron/sync-cricapi/route.ts
@@ -677,8 +677,9 @@ export async function GET(req: NextRequest) {
       }
 
       // Aggregate effective points per team with XI + C/VC multipliers
-      const agg = new Map<string, { total: number; breakdown: Record<string, number> }>();
-      for (const t of teamList) agg.set(t.id, { total: 0, breakdown: {} });
+      const playerNameById = new Map(players.map((p) => [p.id, p.name]));
+      const agg = new Map<string, { total: number; breakdown: Record<string, number>; detail: object[] }>();
+      for (const t of teamList) agg.set(t.id, { total: 0, breakdown: {}, detail: [] });
 
       for (const row of performances) {
         const teamId = playerToTeam.get(row.player_id);
@@ -687,8 +688,8 @@ export async function GET(req: NextRequest) {
         if (!teamRow) continue;
 
         const stats: PlayerMatchStats = { batting: row.batting, bowling: row.bowling, fielding: row.fielding };
-        const { total: baseTotal, breakdown } = scorePlayerMatch(stats);
-        const { effective, counted } = effectivePointsWithLineup(baseTotal, row.player_id, {
+        const { total: baseTotal, breakdown, sections } = scorePlayerMatch(stats);
+        const { effective, counted, multiplier } = effectivePointsWithLineup(baseTotal, row.player_id, {
           startingXiPlayerIds: teamRow.starting_xi_player_ids ?? [],
           captainPlayerId: teamRow.captain_player_id ?? null,
           viceCaptainPlayerId: teamRow.vice_captain_player_id ?? null,
@@ -698,6 +699,20 @@ export async function GET(req: NextRequest) {
         if (!bucket) continue;
         bucket.total += effective;
         mergeBreakdown(bucket.breakdown, breakdown);
+        bucket.detail.push({
+          player_id: row.player_id,
+          player_name: playerNameById.get(row.player_id) ?? null,
+          base_points: baseTotal,
+          multiplier,
+          effective_points: effective,
+          stats: {
+            ...(row.batting ? { batting: row.batting } : {}),
+            ...(row.bowling ? { bowling: row.bowling } : {}),
+            ...(row.fielding ? { fielding: row.fielding } : {}),
+          },
+          sections,
+          breakdown,
+        });
         updatedTotal += 1;
       }
 
@@ -713,6 +728,7 @@ export async function GET(req: NextRequest) {
           breakdown: {
             source: "cricapi_v1",
             engine_version: "auctionroom-ipl-v1",
+            player_lines: b.detail.slice(0, 40),
             ...(unmatched.length > 0 ? { unmatched_names: unmatched } : {}),
           },
         };
@@ -840,8 +856,9 @@ export async function GET(req: NextRequest) {
         effectiveLineups.set(t.id, { xi: effectiveXi, captain: effectiveCaptain, vc: effectiveVc });
       }
 
-      const pAgg = new Map<string, { total: number; breakdown: Record<string, number> }>();
-      for (const t of pTeamList) pAgg.set(t.id, { total: 0, breakdown: {} });
+      const pPlayerNameById = new Map(players.map((p) => [p.id, p.name]));
+      const pAgg = new Map<string, { total: number; breakdown: Record<string, number>; detail: object[] }>();
+      for (const t of pTeamList) pAgg.set(t.id, { total: 0, breakdown: {}, detail: [] });
 
       for (const row of pPerformances) {
         const teamId = pPlayerToTeam.get(row.player_id);
@@ -851,8 +868,8 @@ export async function GET(req: NextRequest) {
 
         const eff = effectiveLineups.get(teamId);
         const stats: PlayerMatchStats = { batting: row.batting, bowling: row.bowling, fielding: row.fielding };
-        const { total: baseTotal, breakdown } = scorePlayerMatch(stats);
-        const { effective, counted } = effectivePointsWithLineup(baseTotal, row.player_id, {
+        const { total: baseTotal, breakdown, sections } = scorePlayerMatch(stats);
+        const { effective, counted, multiplier } = effectivePointsWithLineup(baseTotal, row.player_id, {
           startingXiPlayerIds: eff?.xi ?? teamRow.starting_xi_player_ids ?? [],
           captainPlayerId: eff?.captain ?? teamRow.captain_player_id ?? null,
           viceCaptainPlayerId: eff?.vc ?? teamRow.vice_captain_player_id ?? null,
@@ -862,6 +879,20 @@ export async function GET(req: NextRequest) {
         if (!bucket) continue;
         bucket.total += effective;
         mergeBreakdown(bucket.breakdown, breakdown);
+        bucket.detail.push({
+          player_id: row.player_id,
+          player_name: pPlayerNameById.get(row.player_id) ?? null,
+          base_points: baseTotal,
+          multiplier,
+          effective_points: effective,
+          stats: {
+            ...(row.batting ? { batting: row.batting } : {}),
+            ...(row.bowling ? { bowling: row.bowling } : {}),
+            ...(row.fielding ? { fielding: row.fielding } : {}),
+          },
+          sections,
+          breakdown,
+        });
         updatedTotal += 1;
       }
 
@@ -878,6 +909,7 @@ export async function GET(req: NextRequest) {
             source: "cricapi_v1",
             engine_version: "auctionroom-ipl-v1",
             league_kind: "private",
+            player_lines: b.detail.slice(0, 40),
             ...(pUnmatched.length > 0 ? { unmatched_names: pUnmatched } : {}),
           },
         };

--- a/app/api/scores/calculate/route.ts
+++ b/app/api/scores/calculate/route.ts
@@ -29,9 +29,10 @@ async function mapCricApiNamesToPerformances(
   sportId: string,
   rows: { playerName: string; stats: PlayerMatchStats }[],
 ): Promise<{ performances: PerformanceInput[]; unmatched: string[] }> {
-  const { data: players, error } = await supabase.from("players").select("id, name").eq("sport_id", sportId);
+  const { data: players, error } = await supabase.from("players").select("id, name, name_aliases").eq("sport_id", sportId);
   if (error) throw new Error(error.message);
-  return mapCricApiExtractedToPerformances(players ?? [], rows);
+  const result = mapCricApiExtractedToPerformances(players ?? [], rows);
+  return { performances: result.performances, unmatched: result.unmatched };
 }
 
 /**

--- a/lib/cricapi/map-player-names.test.ts
+++ b/lib/cricapi/map-player-names.test.ts
@@ -5,11 +5,11 @@ describe("matchDbPlayerForCricApiName", () => {
   const pool = [{ id: "1", name: "Virat Kohli" }, { id: "2", name: "Ruturaj Gaikwad" }];
 
   it("maps short initial + last name to full name", () => {
-    expect(matchDbPlayerForCricApiName(pool, "V Kohli")?.id).toBe("1");
+    expect(matchDbPlayerForCricApiName(pool, "V Kohli")?.player.id).toBe("1");
   });
 
   it("maps exact name", () => {
-    expect(matchDbPlayerForCricApiName(pool, "Virat Kohli")?.id).toBe("1");
+    expect(matchDbPlayerForCricApiName(pool, "Virat Kohli")?.player.id).toBe("1");
   });
 
   it("returns null when last name + initial matches more than one player", () => {
@@ -18,6 +18,20 @@ describe("matchDbPlayerForCricApiName", () => {
       { id: "b", name: "Avesh Singh" },
     ];
     expect(matchDbPlayerForCricApiName(twoSingh, "A Singh")).toBeNull();
+  });
+
+  it("matches via Levenshtein for spelling variations", () => {
+    const players = [{ id: "1", name: "Vaibhav Suryavanshi" }];
+    const result = matchDbPlayerForCricApiName(players, "Vaibhav Sooryavanshi");
+    expect(result?.player.id).toBe("1");
+    expect(result?.method).toBe("levenshtein");
+  });
+
+  it("matches via name_aliases", () => {
+    const players = [{ id: "1", name: "Virat Kohli", name_aliases: ["V Kohli Jr", "King Kohli"] }];
+    const result = matchDbPlayerForCricApiName(players, "King Kohli");
+    expect(result?.player.id).toBe("1");
+    expect(result?.method).toBe("alias");
   });
 });
 

--- a/lib/cricapi/map-player-names.ts
+++ b/lib/cricapi/map-player-names.ts
@@ -1,12 +1,8 @@
 import type { PlayerMatchStats } from "@/lib/fantasy-scoring";
 import { normalizeName } from "@/lib/cricapi/fetch-scorecard";
 
-export type DbPlayer = { id: string; name: string };
+export type DbPlayer = { id: string; name: string; name_aliases?: string[] | null };
 
-/**
- * Map a single CricAPI/scorecard display name to one row in our players table.
- * Handles short initials (e.g. "V Kohli" → "Virat Kohli") when the last name is unique.
- */
 /** Normalize with extra cleanup: strip dots, hyphens, apostrophes */
 function deepNormalize(s: string): string {
   return s
@@ -16,18 +12,56 @@ function deepNormalize(s: string): string {
     .trim();
 }
 
-export function matchDbPlayerForCricApiName(list: DbPlayer[], cricName: string): DbPlayer | null {
+/** Levenshtein edit distance between two strings */
+function editDistance(a: string, b: string): number {
+  const m = a.length, n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0) as number[]);
+  for (let i = 0; i <= m; i++) dp[i]![0] = i;
+  for (let j = 0; j <= n; j++) dp[0]![j] = j;
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i]![j] = a[i - 1] === b[j - 1]
+        ? dp[i - 1]![j - 1]!
+        : 1 + Math.min(dp[i - 1]![j]!, dp[i]![j - 1]!, dp[i - 1]![j - 1]!);
+    }
+  }
+  return dp[m]![n]!;
+}
+
+/** Similarity ratio: 0..1 (1 = identical) */
+function similarity(a: string, b: string): number {
+  const maxLen = Math.max(a.length, b.length);
+  if (maxLen === 0) return 1;
+  return 1 - editDistance(a, b) / maxLen;
+}
+
+/**
+ * Map a single CricAPI/scorecard display name to one row in our players table.
+ * Returns the matched player and whether it was a fuzzy/alias match.
+ */
+export function matchDbPlayerForCricApiName(
+  list: DbPlayer[],
+  cricName: string,
+): { player: DbPlayer; method: string } | null {
   const key = normalizeName(cricName);
   if (!key) return null;
 
+  // Stage 0: Check name_aliases (exact match on any alias)
+  const aliasMatch = list.find((p) =>
+    (p.name_aliases ?? []).some((a) => normalizeName(a) === key),
+  );
+  if (aliasMatch) return { player: aliasMatch, method: "alias" };
+
   // Stage 1: Exact normalized match
   const exact = list.find((p) => normalizeName(p.name) === key);
-  if (exact) return exact;
+  if (exact) return { player: exact, method: "exact" };
 
   // Stage 1b: Deep normalize (strip dots, hyphens, apostrophes)
   const deepKey = deepNormalize(cricName);
   const deepExact = list.find((p) => deepNormalize(p.name) === deepKey);
-  if (deepExact) return deepExact;
+  if (deepExact) return { player: deepExact, method: "deep_exact" };
 
   // Stage 2: Fuzzy substring match (both directions)
   const fuzzy = list.find(
@@ -35,7 +69,7 @@ export function matchDbPlayerForCricApiName(list: DbPlayer[], cricName: string):
       key.length >= 4 &&
       (normalizeName(p.name).includes(key) || key.includes(normalizeName(p.name))),
   );
-  if (fuzzy) return fuzzy;
+  if (fuzzy) return { player: fuzzy, method: "substring" };
 
   const parts = key.split(/\s+/).filter(Boolean);
   const last = parts.length ? parts[parts.length - 1]! : "";
@@ -50,14 +84,14 @@ export function matchDbPlayerForCricApiName(list: DbPlayer[], cricName: string):
 
   // For short last names (< 4 chars), try full-string contains before giving up
   if (last.length < 4) {
-    if (lastNameMatches.length === 1) return lastNameMatches[0]!;
-    // Try: does the full CricAPI name appear as a substring of any DB name?
+    if (lastNameMatches.length === 1) return { player: lastNameMatches[0]!, method: "last_name" };
     const containsMatch = list.filter((p) => deepNormalize(p.name).includes(deepKey));
-    if (containsMatch.length === 1) return containsMatch[0]!;
-    // Fall through to initial-based matching below if we have last name matches
-    if (lastNameMatches.length === 0) return null;
+    if (containsMatch.length === 1) return { player: containsMatch[0]!, method: "contains" };
+    if (lastNameMatches.length === 0) {
+      // Fall through to Levenshtein
+    }
   } else {
-    if (lastNameMatches.length === 1) return lastNameMatches[0]!;
+    if (lastNameMatches.length === 1) return { player: lastNameMatches[0]!, method: "last_name" };
   }
 
   // Stage 4: Initial + last name disambiguation
@@ -68,9 +102,8 @@ export function matchDbPlayerForCricApiName(list: DbPlayer[], cricName: string):
       const firstWord = pn.split(/\s+/).filter(Boolean)[0] ?? "";
       return firstWord.startsWith(initial);
     });
-    if (narrowed.length === 1) return narrowed[0]!;
+    if (narrowed.length === 1) return { player: narrowed[0]!, method: "initial_last" };
 
-    // Stage 4b: Try 2-char first name prefix when initial matching fails
     if (narrowed.length === 0 && initial.length >= 2) {
       const prefix2 = initial.slice(0, 2);
       const byPrefix = lastNameMatches.filter((p) => {
@@ -78,7 +111,34 @@ export function matchDbPlayerForCricApiName(list: DbPlayer[], cricName: string):
         const firstWord = pn.split(/\s+/).filter(Boolean)[0] ?? "";
         return firstWord.startsWith(prefix2);
       });
-      if (byPrefix.length === 1) return byPrefix[0]!;
+      if (byPrefix.length === 1) return { player: byPrefix[0]!, method: "prefix2_last" };
+    }
+  }
+
+  // Stage 5: Levenshtein fuzzy match — catches spelling variations
+  // (e.g. "Sooryavanshi" vs "Suryavanshi")
+  // Only accept if: similarity > 0.75, exactly one candidate above threshold,
+  // and first name matches (to avoid cross-player matches)
+  const SIMILARITY_THRESHOLD = 0.75;
+  const candidates: { player: DbPlayer; sim: number }[] = [];
+  for (const p of list) {
+    const sim = similarity(deepKey, deepNormalize(p.name));
+    if (sim >= SIMILARITY_THRESHOLD) {
+      candidates.push({ player: p, sim });
+    }
+  }
+  if (candidates.length === 1) {
+    return { player: candidates[0]!.player, method: "levenshtein" };
+  }
+  // If multiple candidates, try to disambiguate by first name
+  if (candidates.length > 1 && parts.length >= 2) {
+    const firstName = parts[0]!;
+    const byFirst = candidates.filter((c) => {
+      const pFirst = normalizeName(c.player.name).split(/\s+/)[0] ?? "";
+      return pFirst.startsWith(firstName) || firstName.startsWith(pFirst);
+    });
+    if (byFirst.length === 1) {
+      return { player: byFirst[0]!.player, method: "levenshtein_first" };
     }
   }
 
@@ -87,21 +147,43 @@ export function matchDbPlayerForCricApiName(list: DbPlayer[], cricName: string):
 
 export type ExtractedRow = { playerName: string; stats: PlayerMatchStats };
 
+export type AutoCorrection = {
+  player_id: string;
+  db_name: string;
+  cricapi_name: string;
+  method: string;
+};
+
 export function mapCricApiExtractedToPerformances(
   list: DbPlayer[],
   extracted: ExtractedRow[],
-): { performances: Array<{ player_id: string } & PlayerMatchStats>; unmatched: string[] } {
+): {
+  performances: Array<{ player_id: string } & PlayerMatchStats>;
+  unmatched: string[];
+  autoCorrections: AutoCorrection[];
+} {
   const performances: Array<{ player_id: string } & PlayerMatchStats> = [];
   const unmatched: string[] = [];
+  const autoCorrections: AutoCorrection[] = [];
 
   for (const row of extracted) {
-    const p = matchDbPlayerForCricApiName(list, row.playerName);
-    if (!p) {
+    const result = matchDbPlayerForCricApiName(list, row.playerName);
+    if (!result) {
       unmatched.push(row.playerName);
       continue;
     }
-    performances.push({ player_id: p.id, ...row.stats });
+    performances.push({ player_id: result.player.id, ...row.stats });
+
+    // Track fuzzy matches that should be saved as aliases
+    if (result.method === "levenshtein" || result.method === "levenshtein_first") {
+      autoCorrections.push({
+        player_id: result.player.id,
+        db_name: result.player.name,
+        cricapi_name: row.playerName,
+        method: result.method,
+      });
+    }
   }
 
-  return { performances, unmatched };
+  return { performances, unmatched, autoCorrections };
 }

--- a/supabase/migrations/020_player_name_aliases.sql
+++ b/supabase/migrations/020_player_name_aliases.sql
@@ -1,0 +1,26 @@
+-- Add name_aliases column for auto-corrected CricAPI spelling variations.
+-- The cron auto-saves aliases when Levenshtein fuzzy matching resolves a name.
+-- Future matches use alias lookup (instant, no fuzzy needed).
+
+ALTER TABLE players ADD COLUMN IF NOT EXISTS name_aliases TEXT[] DEFAULT '{}';
+
+-- Atomically add a CricAPI name as an alias (idempotent — skips duplicates).
+CREATE OR REPLACE FUNCTION add_player_name_alias(p_player_id UUID, p_alias TEXT)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  UPDATE players
+  SET name_aliases = array_append(name_aliases, p_alias)
+  WHERE id = p_player_id
+    AND NOT (p_alias = ANY(COALESCE(name_aliases, '{}')));
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION add_player_name_alias(UUID, TEXT) TO authenticated, service_role;
+
+-- Seed the known mismatch: CricAPI "Vaibhav Sooryavanshi" → DB "Vaibhav Suryavanshi"
+UPDATE players SET name_aliases = array_append(COALESCE(name_aliases, '{}'), 'Vaibhav Sooryavanshi')
+WHERE name = 'Vaibhav Suryavanshi' AND NOT ('Vaibhav Sooryavanshi' = ANY(COALESCE(name_aliases, '{}')));


### PR DESCRIPTION
## Changes

### Player-level breakdown in cron scoring
- Cron now generates `player_lines` (per-player stats, breakdown, multiplier) same as manual scoring

### Smart auto-correction for player name mismatches
- **Levenshtein edit distance** matching (stage 5, threshold 0.75 similarity) catches spelling variations like 'Vaibhav Sooryavanshi' → 'Vaibhav Suryavanshi'
- **Alias matching** (stage 0) for instant lookups of previously-corrected names
- Auto-saves CricAPI name as alias when fuzzy match succeeds — future matches resolve instantly
- `name_aliases TEXT[]` column on players table + `add_player_name_alias` RPC
- 6-stage matching: alias → exact → deep-normalize → fuzzy substring → last name → initial+last → Levenshtein

### Migration 020
- Adds `name_aliases` column
- Creates `add_player_name_alias` idempotent RPC
- Seeds known alias: Vaibhav Sooryavanshi

### Tests
- 150 tests pass (including new Levenshtein + alias test cases)