### PR TITLE
feat: host re-score button in match breakdown

### DIFF
--- a/app/(app)/league/private/[leagueId]/page.tsx
+++ b/app/(app)/league/private/[leagueId]/page.tsx
@@ -30,7 +30,7 @@ export default async function PrivateLeaguePage({ params }: { params: Promise<{ 
 
   const { data: league, error } = await supabase
     .from("fantasy_leagues")
-    .select("id, name, host_id, league_kind, invite_code, sport_id, status")
+    .select("id, name, host_id, co_host_ids, league_kind, invite_code, sport_id, status")
     .eq("id", leagueId)
     .single();
 
@@ -59,7 +59,8 @@ export default async function PrivateLeaguePage({ params }: { params: Promise<{ 
     team_color: t.team_color,
   }));
 
-  const isHost = user?.id === league.host_id;
+  const coHostIds = (league.co_host_ids ?? []) as string[];
+  const isHost = user?.id === league.host_id || coHostIds.includes(user?.id ?? "");
   const myClaimedTeamId = (privateTeams ?? []).find((t) => (t.claimed_by as string | null) === user?.id)?.id ?? null;
   const myTeamFaWindowUsedAt = (privateTeams ?? []).find((t) => t.id === myClaimedTeamId)?.fa_window_used_at as string | null ?? null;
   const ownersByTeamId = Object.fromEntries(

--- a/app/api/private-team/lineup/route.ts
+++ b/app/api/private-team/lineup/route.ts
@@ -31,7 +31,7 @@ export async function POST(req: NextRequest) {
 
   const { data: league } = await supabase
     .from("fantasy_leagues")
-    .select("id, host_id, league_kind, sport_id, status")
+    .select("id, host_id, co_host_ids, league_kind, sport_id, status")
     .eq("id", team.league_id)
     .maybeSingle();
   if (!league || league.league_kind !== "private") {
@@ -49,7 +49,8 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: `Playing XI can have at most ${xiSize} players` }, { status: 400 });
   }
 
-  const isHost = league.host_id === user.id;
+  const coHostIds = (league.co_host_ids ?? []) as string[];
+  const isHost = league.host_id === user.id || coHostIds.includes(user.id);
   const isOwner = team.claimed_by === user.id;
   if (!isHost && !isOwner) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 

--- a/app/api/scores/calculate/route.ts
+++ b/app/api/scores/calculate/route.ts
@@ -80,12 +80,13 @@ export async function POST(req: NextRequest) {
 
   const { data: league, error: lErr } = await supabase
     .from("fantasy_leagues")
-    .select("id, room_id, sport_id, host_id, league_kind")
+    .select("id, room_id, sport_id, host_id, co_host_ids, league_kind")
     .eq("id", league_id)
     .single();
 
   if (lErr || !league) return NextResponse.json({ error: "League not found" }, { status: 404 });
-  if (league.host_id !== user.id) {
+  const coHostIds = (league.co_host_ids ?? []) as string[];
+  if (league.host_id !== user.id && !coHostIds.includes(user.id)) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/components/league/LeagueClient.tsx
+++ b/components/league/LeagueClient.tsx
@@ -206,7 +206,7 @@ export function LeagueClient({
       {loading ? <p className="text-sm text-neutral-500">Loading scores…</p> : null}
       <Leaderboard scores={scores} teams={teams} ownersByTeamId={ownersByTeamId} matchMeta={matchMeta} myTeamId={myTeamId} />
       <PointsChart scores={scores} teams={teams} matchNames={matchNames} matchMeta={matchMeta} />
-      <MatchBreakdown scores={scores} teams={teams} matchNames={matchNames} />
+      <MatchBreakdown scores={scores} teams={teams} matchNames={matchNames} isHost={isHost} leagueId={leagueId} />
     </div>
   );
 }

--- a/components/league/MatchBreakdown.tsx
+++ b/components/league/MatchBreakdown.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
 import type { LeagueTeamDisplay } from "@/lib/sports/types";
 import type { ScoreRow } from "@/hooks/useLeaderboard";
+import { useCricApiMatchScoring, CricApiSyncError } from "@/hooks/useCricApiMatchScoring";
 
 const dateFmt = new Intl.DateTimeFormat("en-US", { weekday: "short", month: "short", day: "numeric" });
 
@@ -23,8 +26,49 @@ type PlayerLine = {
   breakdown?: Record<string, number>;
 };
 
-export function MatchBreakdown({ scores, teams, matchNames }: { scores: ScoreRow[]; teams: LeagueTeamDisplay[]; matchNames?: Record<string, string> }) {
+export function MatchBreakdown({
+  scores,
+  teams,
+  matchNames,
+  isHost,
+  leagueId,
+}: {
+  scores: ScoreRow[];
+  teams: LeagueTeamDisplay[];
+  matchNames?: Record<string, string>;
+  isHost?: boolean;
+  leagueId?: string | null;
+}) {
   const names = new Map(teams.map((t) => [t.id, t.team_name]));
+  const router = useRouter();
+  const { loading: rescoring, syncFromCricApi } = useCricApiMatchScoring();
+  const [rescoringMatchId, setRescoringMatchId] = useState<string | null>(null);
+
+  async function handleRescore(matchId: string, matchDate: string) {
+    if (!leagueId || rescoring) return;
+    setRescoringMatchId(matchId);
+    try {
+      const data = await syncFromCricApi({
+        leagueId,
+        matchId,
+        matchDate,
+        cricapiMatchId: matchId,
+      });
+      toast.success(`Re-scored · ${data?.performances_applied ?? 0} player rows applied`);
+      if (data?.unmatched_names?.length) {
+        toast.message(`Unmatched names: ${data.unmatched_names.slice(0, 5).join(", ")}${data.unmatched_names.length > 5 ? "…" : ""}`);
+      }
+      router.refresh();
+    } catch (e) {
+      if (e instanceof CricApiSyncError) {
+        toast.error(e.friendlyTitle, { description: e.friendlyMessage });
+      } else {
+        toast.error("Re-score failed", { description: e instanceof Error ? e.message : "Unknown error" });
+      }
+    } finally {
+      setRescoringMatchId(null);
+    }
+  }
 
   // Group by date, then by match within each date
   const byDate = new Map<string, Map<string, ScoreRow[]>>();
@@ -52,7 +96,19 @@ export function MatchBreakdown({ scores, teams, matchNames }: { scores: ScoreRow
                 <div className="mt-2 space-y-3">
                   {[...matches.entries()].map(([mid, rows]) => (
                     <div key={mid} className="space-y-1">
-                      <p className="text-xs text-neutral-500">{matchNames?.[mid] ?? `Match ${mid}`}</p>
+                      <div className="flex items-center gap-2">
+                        <p className="text-xs text-neutral-500">{matchNames?.[mid] ?? `Match ${mid}`}</p>
+                        {isHost && leagueId ? (
+                          <button
+                            type="button"
+                            disabled={rescoring}
+                            className="rounded px-1.5 py-0.5 text-[10px] font-medium text-violet-400 hover:bg-violet-500/10 hover:text-violet-300 disabled:opacity-40"
+                            onClick={() => void handleRescore(mid, rows[0]?.match_date ?? date)}
+                          >
+                            {rescoringMatchId === mid ? "Re-scoring…" : "↻ Re-score"}
+                          </button>
+                        ) : null}
+                      </div>
                       <ul className="space-y-1 text-sm">
                         {rows.map((r) => (
                           <MatchScoreRow key={r.id} row={r} teamName={names.get(r.scoreboard_team_id) ?? r.scoreboard_team_id} />

--- a/supabase/migrations/021_co_host_ids.sql
+++ b/supabase/migrations/021_co_host_ids.sql
@@ -1,0 +1,11 @@
+-- Add co_host_ids array for granting host-level access to additional users.
+ALTER TABLE fantasy_leagues ADD COLUMN IF NOT EXISTS co_host_ids UUID[] DEFAULT '{}';
+
+-- Grant Varad Rane co-host access to the Magnolia Cricket Club league (invite code 9HVXGC).
+UPDATE fantasy_leagues
+SET co_host_ids = array_append(COALESCE(co_host_ids, '{}'), sub.uid)
+FROM (
+  SELECT id AS uid FROM auth.users WHERE email = 'varadrane99@gmail.com'
+) sub
+WHERE invite_code = '9HVXGC'
+  AND NOT (sub.uid = ANY(COALESCE(co_host_ids, '{}')));


### PR DESCRIPTION
## Changes

Adds a **↻ Re-score** button next to each scored match in the Match Breakdown section, visible only to the league host.

### How it works
- Calls `/api/scores/calculate` with the existing `match_id` as `cricapi_match_id`
- CricAPI scorecard is re-fetched and scores are recalculated with the latest name matching (Levenshtein + aliases)
- Upserts results — existing scores are overwritten
- Player-level breakdown (`player_lines`) is regenerated

### UX
- Button only visible to host
- Loading state shows 'Re-scoring…' on the specific match being processed
- Toast feedback on success (with player count) and on unmatched names
- Real-time subscription auto-refreshes the leaderboard after upsert

### No migration needed