### PR TITLE
Day-aware Playing XI lock window (closes #56)

### DIFF
--- a/app/(app)/league/private/[leagueId]/page.tsx
+++ b/app/(app)/league/private/[leagueId]/page.tsx
@@ -380,6 +380,7 @@ export default async function PrivateLeaguePage({ params }: { params: Promise<{ 
                               initialXi={Array.isArray(t.starting_xi_player_ids) ? (t.starting_xi_player_ids as string[]) : []}
                               captainPlayerId={t.captain_player_id as string | null}
                               viceCaptainPlayerId={t.vice_captain_player_id as string | null}
+                              xiConfirmed={xiConfirmed}
                             />
                           ) : isMine && league.status === "draft" ? (
                             <p className="mt-4 text-sm text-neutral-400">Set your Playing XI once the host starts the league.</p>

--- a/app/api/private-team/lineup/route.ts
+++ b/app/api/private-team/lineup/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { getSportConfig } from "@/lib/sports";
 import { validateXiComposition } from "@/lib/xi-composition";
+import { getWindowStatus } from "@/lib/lineup-lock";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(req: NextRequest) {
@@ -121,6 +122,23 @@ export async function POST(req: NextRequest) {
 
   if (captain_player_id && vice_captain_player_id && captain_player_id === vice_captain_player_id) {
     return NextResponse.json({ error: "Captain and vice-captain must be different players" }, { status: 400 });
+  }
+
+  // Lineup change time-window lock.
+  // Bypass for first-ever XI confirmation so users onboarding mid-match can still set their initial XI.
+  const isFirstXiSetup = !team.xi_confirmed_at;
+  if (!isFirstXiSetup) {
+    const windowStatus = getWindowStatus();
+    if (!windowStatus.open) {
+      return NextResponse.json(
+        {
+          error: "Lineup changes are locked while matches are in progress. Try again when the window reopens.",
+          code: "LINEUP_LOCKED",
+          opens_at: windowStatus.opensAt.toISOString(),
+        },
+        { status: 403 },
+      );
+    }
   }
 
   const updatePayload: Record<string, unknown> = {

--- a/app/api/private-team/lineup/route.ts
+++ b/app/api/private-team/lineup/route.ts
@@ -125,8 +125,9 @@ export async function POST(req: NextRequest) {
   }
 
   // Lineup change time-window lock.
-  // Bypass for first-ever XI confirmation so users onboarding mid-match can still set their initial XI.
-  const isFirstXiSetup = !team.xi_confirmed_at;
+  // Bypass only for first-ever XI confirmation (i.e. a non-empty XI being set for the first time).
+  // An empty-XI save never qualifies as first setup — otherwise it could be abused to wipe an XI during lock.
+  const isFirstXiSetup = !team.xi_confirmed_at && xi.length > 0;
   if (!isFirstXiSetup) {
     const windowStatus = getWindowStatus();
     if (!windowStatus.open) {

--- a/components/private-league/PrivateLineupPanel.tsx
+++ b/components/private-league/PrivateLineupPanel.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { PlayerMeta } from "@/components/player/PlayerMeta";
 import { validateXiComposition } from "@/lib/xi-composition";
+import { getWindowStatus, formatWindowBoundary } from "@/lib/lineup-lock";
 
 export type PrivateTeamPlayer = {
   playerId: string;
@@ -22,6 +23,7 @@ export function PrivateLineupPanel({
   initialXi,
   captainPlayerId,
   viceCaptainPlayerId,
+  xiConfirmed,
 }: {
   privateTeamId: string;
   players: PrivateTeamPlayer[];
@@ -30,11 +32,25 @@ export function PrivateLineupPanel({
   initialXi: string[];
   captainPlayerId: string | null;
   viceCaptainPlayerId: string | null;
+  /** True once the team has confirmed their XI at least once. While false, lock is bypassed. */
+  xiConfirmed: boolean;
 }) {
   const [xi, setXi] = useState<Set<string>>(() => new Set(initialXi));
   const [c, setC] = useState<string | null>(captainPlayerId);
   const [vc, setVc] = useState<string | null>(viceCaptainPlayerId);
   const [saving, setSaving] = useState(false);
+  const [windowState, setWindowState] = useState(() => getWindowStatus());
+
+  // Refresh window status every 30s so the UI transitions without a reload.
+  useEffect(() => {
+    const id = setInterval(() => setWindowState(getWindowStatus()), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Lock is only enforced after the first XI has been confirmed.
+  const locked = xiConfirmed && !windowState.open;
+  const opensAtFmt = useMemo(() => formatWindowBoundary(windowState.opensAt), [windowState.opensAt]);
+  const closesAtFmt = useMemo(() => formatWindowBoundary(windowState.closesAt), [windowState.closesAt]);
 
   useEffect(() => {
     const squadSize = players.length;
@@ -81,9 +97,13 @@ export function PrivateLineupPanel({
     return { wk, bat, bowl, all };
   }, [players, xi]);
 
-  const canSave = canSetFullXi && xiComplete && hasCaptainAndVc && compositionResult.valid;
+  const canSave = canSetFullXi && xiComplete && hasCaptainAndVc && compositionResult.valid && !locked;
 
   function toggle(pid: string) {
+    if (locked) {
+      toast.error("Lineup is locked. Matches are in progress.");
+      return;
+    }
     setXi((prev) => {
       const next = new Set(prev);
       if (next.has(pid)) {
@@ -111,16 +131,22 @@ export function PrivateLineupPanel({
   }
 
   function setCaptain(pid: string) {
+    if (locked) return;
     setC(pid);
     if (vc === pid) setVc(null);
   }
 
   function setViceCaptain(pid: string) {
+    if (locked) return;
     setVc(pid);
     if (c === pid) setC(null);
   }
 
   async function save() {
+    if (locked) {
+      toast.error(`Lineup locked. Reopens ${opensAtFmt.pt} PT`);
+      return;
+    }
     setSaving(true);
     try {
       const xiArr = [...xi];
@@ -139,8 +165,14 @@ export function PrivateLineupPanel({
           vice_captain_player_id: vc,
         }),
       });
-      const data = (await res.json()) as { error?: string };
-      if (!res.ok) throw new Error(data.error || "Save failed");
+      const data = (await res.json()) as { error?: string; code?: string; opens_at?: string };
+      if (!res.ok) {
+        if (data.code === "LINEUP_LOCKED" && data.opens_at) {
+          const f = formatWindowBoundary(new Date(data.opens_at));
+          throw new Error(`Lineup locked. Reopens ${f.pt} PT · ${f.et} ET · ${f.ist} IST`);
+        }
+        throw new Error(data.error || "Save failed");
+      }
       toast.success("Lineup saved");
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Failed");
@@ -190,12 +222,29 @@ export function PrivateLineupPanel({
         </div>
       </div>
 
+      {locked ? (
+        <div className="border-b border-amber-500/20 bg-amber-500/10 px-4 py-3 text-xs text-amber-200">
+          <p className="font-semibold">🔒 Lineup locked — matches are in progress</p>
+          <p className="mt-1 text-amber-200/80">
+            Changes reopen <span className="font-medium text-amber-100">{opensAtFmt.pt} PT</span>
+            {" · "}<span className="text-amber-200/70">{opensAtFmt.et} ET</span>
+            {" · "}<span className="text-amber-200/70">{opensAtFmt.ist} IST</span>
+          </p>
+        </div>
+      ) : xiConfirmed ? (
+        <div className="border-b border-neutral-800/80 px-4 py-2 text-xs text-neutral-400">
+          Changes open until <span className="font-medium text-neutral-200">{closesAtFmt.pt} PT</span>
+          {" · "}<span className="text-neutral-500">{closesAtFmt.et} ET</span>
+          {" · "}<span className="text-neutral-500">{closesAtFmt.ist} IST</span>
+        </div>
+      ) : null}
+
       <ul className="max-h-72 space-y-2 overflow-y-auto p-4">
         {players.map((p) => {
           const on = xi.has(p.playerId);
           const isC = c === p.playerId;
           const isVC = vc === p.playerId;
-          const disablePick = !canSetFullXi && !on;
+          const disablePick = (!canSetFullXi && !on) || locked;
           return (
             <li
               key={p.playerId}
@@ -221,7 +270,8 @@ export function PrivateLineupPanel({
                   <button
                     type="button"
                     onClick={() => setCaptain(p.playerId)}
-                    className={`cursor-pointer rounded-full px-2 py-1 font-semibold ring-1 transition-colors ${
+                    disabled={locked}
+                    className={`cursor-pointer rounded-full px-2 py-1 font-semibold ring-1 transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
                       isC ? "bg-blue-500/15 text-blue-200 ring-blue-500/30" : "bg-neutral-900/40 text-neutral-400 ring-neutral-700/80 hover:text-neutral-200"
                     }`}
                   >
@@ -230,7 +280,8 @@ export function PrivateLineupPanel({
                   <button
                     type="button"
                     onClick={() => setViceCaptain(p.playerId)}
-                    className={`cursor-pointer rounded-full px-2 py-1 font-semibold ring-1 transition-colors ${
+                    disabled={locked}
+                    className={`cursor-pointer rounded-full px-2 py-1 font-semibold ring-1 transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
                       isVC ? "bg-sky-500/15 text-sky-200 ring-sky-500/30" : "bg-neutral-900/40 text-neutral-400 ring-neutral-700/80 hover:text-neutral-200"
                     }`}
                   >
@@ -254,7 +305,9 @@ export function PrivateLineupPanel({
           {saving ? "Saving…" : "Save lineup"}
         </Button>
         <span className="text-xs text-neutral-500">
-          {xi.size === xiSize && !compositionResult.valid ? (
+          {locked ? (
+            <span className="text-amber-300">Locked — reopens {opensAtFmt.pt} PT</span>
+          ) : xi.size === xiSize && !compositionResult.valid ? (
             <span className="text-red-300">{compositionResult.errors.join("; ")}</span>
           ) : xi.size === xiSize && !hasCaptainAndVc ? (
             <span className="text-amber-300">Select Captain &amp; Vice-Captain to save</span>

--- a/components/private-league/PrivateLineupPanel.tsx
+++ b/components/private-league/PrivateLineupPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { PlayerMeta } from "@/components/player/PlayerMeta";
@@ -40,6 +41,10 @@ export function PrivateLineupPanel({
   const [vc, setVc] = useState<string | null>(viceCaptainPlayerId);
   const [saving, setSaving] = useState(false);
   const [windowState, setWindowState] = useState(() => getWindowStatus());
+  // Mirror of server-side xi_confirmed_at flipped after a successful save so
+  // the lock kicks in without a full reload (router.refresh() also runs).
+  const [confirmedLocally, setConfirmedLocally] = useState(false);
+  const router = useRouter();
 
   // Refresh window status every 30s so the UI transitions without a reload.
   useEffect(() => {
@@ -48,7 +53,8 @@ export function PrivateLineupPanel({
   }, []);
 
   // Lock is only enforced after the first XI has been confirmed.
-  const locked = xiConfirmed && !windowState.open;
+  const effectivelyConfirmed = xiConfirmed || confirmedLocally;
+  const locked = effectivelyConfirmed && !windowState.open;
   const opensAtFmt = useMemo(() => formatWindowBoundary(windowState.opensAt), [windowState.opensAt]);
   const closesAtFmt = useMemo(() => formatWindowBoundary(windowState.closesAt), [windowState.closesAt]);
 
@@ -174,6 +180,12 @@ export function PrivateLineupPanel({
         throw new Error(data.error || "Save failed");
       }
       toast.success("Lineup saved");
+      // If this was the first-ever confirmation, flip local state so the lock
+      // takes effect immediately, and refresh server props.
+      if ([...xi].length > 0 && !xiConfirmed) {
+        setConfirmedLocally(true);
+      }
+      router.refresh();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Failed");
     } finally {

--- a/lib/lineup-lock.test.ts
+++ b/lib/lineup-lock.test.ts
@@ -145,6 +145,43 @@ describe("formatWindowBoundary", () => {
   });
 });
 
+// DST correctness: the `ptDateAtHour` helper contains a nudge branch that
+// corrects for DST when the computed UTC candidate lands on the wrong PT hour.
+// These fixtures exercise both transitions so regressions in that branch fail loudly.
+describe("getWindowStatus — DST transitions", () => {
+  // Fall back: Sun 2025-11-02 02:00 PDT → 01:00 PST (gain an hour).
+  // Window on Sat Nov 1 2025 20:00 PDT is open; next close is Sun Nov 2 03:00 PT.
+  // At that instant the clock is already PST (UTC-8), so 03:00 PST = 11:00 UTC.
+  it("Sat 8 PM PDT (Nov 1 2025) → closesAt is Sun 3 AM PST (post fall-back)", () => {
+    // Sat 2025-11-01 20:00 PDT = 2025-11-02 03:00 UTC
+    const now = new Date(Date.UTC(2025, 10, 2, 3, 0, 0, 0));
+    const s = getWindowStatus(now);
+    expect(s.open).toBe(true);
+    expect(s.closesAt.getTime()).toBe(Date.UTC(2025, 10, 2, 11, 0, 0, 0));
+  });
+
+  // Spring forward: Sun 2026-03-08 02:00 PST jumps to 03:00 PDT (lose an hour).
+  // 03:00 PDT on that day = 10:00 UTC (the first valid 3 AM on the PT calendar day).
+  // Window on Sat Mar 7 2026 20:00 PST is open; next close is Sun Mar 8 03:00 PT.
+  it("Sat 8 PM PST (Mar 7 2026) → closesAt is Sun 3 AM PDT (post spring-forward)", () => {
+    // Sat 2026-03-07 20:00 PST = 2026-03-08 04:00 UTC
+    const now = new Date(Date.UTC(2026, 2, 8, 4, 0, 0, 0));
+    const s = getWindowStatus(now);
+    expect(s.open).toBe(true);
+    expect(s.closesAt.getTime()).toBe(Date.UTC(2026, 2, 8, 10, 0, 0, 0));
+  });
+
+  // Right after spring forward, at 4 AM PDT Sunday the window is closed
+  // (Sun weekend close = 3 AM), opensAt should be Sun 15:00 PDT = 22:00 UTC.
+  it("Sun 4 AM PDT (Mar 8 2026, just after spring-forward) → opensAt is 3 PM PDT same day", () => {
+    // Sun 2026-03-08 04:00 PDT = 2026-03-08 11:00 UTC
+    const now = new Date(Date.UTC(2026, 2, 8, 11, 0, 0, 0));
+    const s = getWindowStatus(now);
+    expect(s.open).toBe(false);
+    expect(s.opensAt.getTime()).toBe(Date.UTC(2026, 2, 8, 22, 0, 0, 0));
+  });
+});
+
 describe("constants", () => {
   it("exports correct window hours", () => {
     expect(WINDOW_OPEN_HOUR).toBe(15);

--- a/lib/lineup-lock.test.ts
+++ b/lib/lineup-lock.test.ts
@@ -1,78 +1,154 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { isLineupChangeWindowOpen, getWindowStatus, WINDOW_OPEN_HOUR, WINDOW_CLOSE_HOUR } from "./lineup-lock";
+import { describe, expect, it } from "vitest";
+import {
+  isLineupChangeWindowOpen,
+  getWindowStatus,
+  getWindowCloseHour,
+  formatWindowBoundary,
+  WINDOW_OPEN_HOUR,
+  WEEKDAY_CLOSE_HOUR,
+  WEEKEND_CLOSE_HOUR,
+} from "./lineup-lock";
 
-/** Create a Date object for a specific Pacific time hour on a given date. */
-function makeDateAtPacificHour(hour: number, minute = 0): Date {
-  // Use a known date where PDT applies (July 15 2025, UTC-7)
-  // PT hour 15 = UTC hour 22
+/**
+ * Build a UTC Date that lands at `hour:minute` PT on the given UTC `yyyy-mm-dd`.
+ * Uses PDT (-07:00) offset. We use summer dates (PDT) for all fixtures.
+ */
+function makePt(yyyy: number, mm: number, dd: number, hour: number, minute = 0): Date {
   const utcHour = hour + 7; // PDT offset
-  const d = new Date(Date.UTC(2025, 6, 15, utcHour, minute, 0, 0));
-  return d;
+  return new Date(Date.UTC(yyyy, mm - 1, dd, utcHour, minute, 0, 0));
 }
 
-describe("isLineupChangeWindowOpen", () => {
-  it("returns true at 3 PM PT (window opens)", () => {
-    expect(isLineupChangeWindowOpen(makeDateAtPacificHour(15))).toBe(true);
-  });
+// Fixture days (July 2025, all PDT):
+//   Fri  = 2025-07-11
+//   Sat  = 2025-07-12
+//   Sun  = 2025-07-13
+//   Mon  = 2025-07-14
+//   Tue  = 2025-07-15
 
-  it("returns true at 11 PM PT", () => {
-    expect(isLineupChangeWindowOpen(makeDateAtPacificHour(23))).toBe(true);
+describe("getWindowCloseHour", () => {
+  it("returns 6 AM for weekdays", () => {
+    for (const dow of [1, 2, 3, 4, 5]) {
+      expect(getWindowCloseHour(dow)).toBe(WEEKDAY_CLOSE_HOUR);
+    }
   });
-
-  it("returns true at midnight PT", () => {
-    expect(isLineupChangeWindowOpen(makeDateAtPacificHour(0))).toBe(true);
+  it("returns 3 AM for Saturday and Sunday", () => {
+    expect(getWindowCloseHour(0)).toBe(WEEKEND_CLOSE_HOUR); // Sun
+    expect(getWindowCloseHour(6)).toBe(WEEKEND_CLOSE_HOUR); // Sat
   });
+});
 
-  it("returns true at 5 AM PT", () => {
-    expect(isLineupChangeWindowOpen(makeDateAtPacificHour(5))).toBe(true);
+describe("isLineupChangeWindowOpen — weekdays", () => {
+  it("returns true at 3 PM PT Tue (window opens)", () => {
+    expect(isLineupChangeWindowOpen(makePt(2025, 7, 15, 15))).toBe(true);
   });
-
-  it("returns false at 6 AM PT (window closes)", () => {
-    expect(isLineupChangeWindowOpen(makeDateAtPacificHour(6))).toBe(false);
+  it("returns true at 11 PM PT Tue", () => {
+    expect(isLineupChangeWindowOpen(makePt(2025, 7, 15, 23))).toBe(true);
   });
-
-  it("returns false at 10 AM PT", () => {
-    expect(isLineupChangeWindowOpen(makeDateAtPacificHour(10))).toBe(false);
+  it("returns true at midnight PT Tue", () => {
+    expect(isLineupChangeWindowOpen(makePt(2025, 7, 15, 0))).toBe(true);
   });
-
-  it("returns false at 2 PM PT", () => {
-    expect(isLineupChangeWindowOpen(makeDateAtPacificHour(14))).toBe(false);
+  it("returns true at 5 AM PT Tue", () => {
+    expect(isLineupChangeWindowOpen(makePt(2025, 7, 15, 5))).toBe(true);
   });
+  it("returns false at 6 AM PT Tue (weekday close)", () => {
+    expect(isLineupChangeWindowOpen(makePt(2025, 7, 15, 6))).toBe(false);
+  });
+  it("returns false at 10 AM PT Tue", () => {
+    expect(isLineupChangeWindowOpen(makePt(2025, 7, 15, 10))).toBe(false);
+  });
+  it("returns false at 2:59 PM PT Tue", () => {
+    expect(isLineupChangeWindowOpen(makePt(2025, 7, 15, 14, 59))).toBe(false);
+  });
+});
 
-  it("returns false at 2:59 PM PT", () => {
-    expect(isLineupChangeWindowOpen(makeDateAtPacificHour(14, 59))).toBe(false);
+describe("isLineupChangeWindowOpen — weekends", () => {
+  it("returns true at 2:59 AM PT Saturday", () => {
+    expect(isLineupChangeWindowOpen(makePt(2025, 7, 12, 2, 59))).toBe(true);
+  });
+  it("returns false at 3 AM PT Saturday (weekend close)", () => {
+    expect(isLineupChangeWindowOpen(makePt(2025, 7, 12, 3))).toBe(false);
+  });
+  it("returns false at 5 AM PT Saturday", () => {
+    expect(isLineupChangeWindowOpen(makePt(2025, 7, 12, 5))).toBe(false);
+  });
+  it("returns false at 5 AM PT Sunday", () => {
+    expect(isLineupChangeWindowOpen(makePt(2025, 7, 13, 5))).toBe(false);
+  });
+  it("returns true at 3 PM PT Sunday (reopen)", () => {
+    expect(isLineupChangeWindowOpen(makePt(2025, 7, 13, 15))).toBe(true);
   });
 });
 
 describe("getWindowStatus", () => {
-  it("returns open=true during open window", () => {
-    const status = getWindowStatus(makeDateAtPacificHour(20));
-    expect(status.open).toBe(true);
+  it("returns open=true during weekday open window", () => {
+    expect(getWindowStatus(makePt(2025, 7, 15, 20)).open).toBe(true);
   });
-
-  it("returns open=false during closed window", () => {
-    const status = getWindowStatus(makeDateAtPacificHour(10));
-    expect(status.open).toBe(false);
+  it("returns open=false during weekday closed window", () => {
+    expect(getWindowStatus(makePt(2025, 7, 15, 10)).open).toBe(false);
   });
-
   it("opensAt is in the future when window is closed", () => {
-    const now = makeDateAtPacificHour(10);
-    const status = getWindowStatus(now);
-    expect(status.open).toBe(false);
-    expect(status.opensAt.getTime()).toBeGreaterThan(now.getTime());
+    const now = makePt(2025, 7, 15, 10);
+    const s = getWindowStatus(now);
+    expect(s.open).toBe(false);
+    expect(s.opensAt.getTime()).toBeGreaterThan(now.getTime());
+  });
+  it("closesAt is in the future when window is open", () => {
+    const now = makePt(2025, 7, 15, 20);
+    const s = getWindowStatus(now);
+    expect(s.open).toBe(true);
+    expect(s.closesAt.getTime()).toBeGreaterThan(now.getTime());
   });
 
-  it("closesAt is in the future when window is open", () => {
-    const now = makeDateAtPacificHour(20);
-    const status = getWindowStatus(now);
-    expect(status.open).toBe(true);
-    expect(status.closesAt.getTime()).toBeGreaterThan(now.getTime());
+  it("Friday 11 PM PT → closesAt is Saturday 3 AM PT (weekend close)", () => {
+    const now = makePt(2025, 7, 11, 23);
+    const s = getWindowStatus(now);
+    expect(s.open).toBe(true);
+    // Saturday 3 AM PT = 2025-07-12 10:00 UTC (PDT)
+    expect(s.closesAt.getTime()).toBe(Date.UTC(2025, 6, 12, 10, 0, 0, 0));
+  });
+
+  it("Saturday 4 AM PT (closed) → opensAt is Saturday 3 PM PT same day", () => {
+    const now = makePt(2025, 7, 12, 4);
+    const s = getWindowStatus(now);
+    expect(s.open).toBe(false);
+    // Saturday 3 PM PT = 2025-07-12 22:00 UTC
+    expect(s.opensAt.getTime()).toBe(Date.UTC(2025, 6, 12, 22, 0, 0, 0));
+  });
+
+  it("Saturday 8 PM PT → closesAt is Sunday 3 AM PT (weekend close)", () => {
+    const now = makePt(2025, 7, 12, 20);
+    const s = getWindowStatus(now);
+    expect(s.open).toBe(true);
+    // Sunday 3 AM PT = 2025-07-13 10:00 UTC
+    expect(s.closesAt.getTime()).toBe(Date.UTC(2025, 6, 13, 10, 0, 0, 0));
+  });
+
+  it("Sunday 8 PM PT → closesAt is Monday 6 AM PT (weekday close)", () => {
+    const now = makePt(2025, 7, 13, 20);
+    const s = getWindowStatus(now);
+    expect(s.open).toBe(true);
+    // Monday 6 AM PT = 2025-07-14 13:00 UTC
+    expect(s.closesAt.getTime()).toBe(Date.UTC(2025, 6, 14, 13, 0, 0, 0));
+  });
+});
+
+describe("formatWindowBoundary", () => {
+  it("returns strings for PT, ET, IST", () => {
+    const d = makePt(2025, 7, 12, 15); // Saturday 3 PM PT
+    const f = formatWindowBoundary(d);
+    expect(typeof f.pt).toBe("string");
+    expect(typeof f.et).toBe("string");
+    expect(typeof f.ist).toBe("string");
+    expect(f.pt.length).toBeGreaterThan(0);
+    expect(f.et.length).toBeGreaterThan(0);
+    expect(f.ist.length).toBeGreaterThan(0);
   });
 });
 
 describe("constants", () => {
   it("exports correct window hours", () => {
     expect(WINDOW_OPEN_HOUR).toBe(15);
-    expect(WINDOW_CLOSE_HOUR).toBe(6);
+    expect(WEEKDAY_CLOSE_HOUR).toBe(6);
+    expect(WEEKEND_CLOSE_HOUR).toBe(3);
   });
 });

--- a/lib/lineup-lock.ts
+++ b/lib/lineup-lock.ts
@@ -1,38 +1,97 @@
 /**
- * Lineup change time-window utility.
+ * Lineup change time-window utility (day-aware).
  *
- * Changes to Playing XI are allowed between 3 PM and 6 AM Pacific Time.
- * Outside that window the lineup is locked (matches are in progress).
+ * Window is OPEN when users can change their Playing XI.
+ * Window is CLOSED while matches are in progress (lineup is locked).
  *
- * The window spans midnight:
- *   OPEN:   15:00 PT  →  05:59 PT (next day)
- *   CLOSED: 06:00 PT  →  14:59 PT
+ *   Mon–Fri: CLOSED 6 AM – 3 PM PT  →  OPEN 3 PM – 6 AM (next day) PT
+ *   Sat, Sun: CLOSED 3 AM – 3 PM PT  →  OPEN 3 PM – 3 AM (next day) PT
+ *
+ * The close hour varies by the PT day-of-week; the open hour is 3 PM PT daily.
  */
 
 const TZ = "America/Los_Angeles";
 export const WINDOW_OPEN_HOUR = 15; // 3 PM PT
-export const WINDOW_CLOSE_HOUR = 6; // 6 AM PT
+export const WEEKDAY_CLOSE_HOUR = 6; // 6 AM PT (Mon–Fri)
+export const WEEKEND_CLOSE_HOUR = 3; // 3 AM PT (Sat, Sun)
 
-/** Get the current hour (0-23) in Pacific time, DST-aware. */
-function pacificHour(now: Date = new Date()): number {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone: TZ,
-    hour: "numeric",
-    hour12: false,
-  }).formatToParts(now);
-  const hourPart = parts.find((p) => p.type === "hour");
-  return parseInt(hourPart?.value ?? "0", 10);
+/** 0 = Sun, 6 = Sat. */
+function isWeekend(dow: number): boolean {
+  return dow === 0 || dow === 6;
 }
 
-/** True when lineup changes are allowed (3 PM – 6 AM Pacific). */
+/** Close hour for a given PT day-of-week (0=Sun..6=Sat). */
+export function getWindowCloseHour(dow: number): number {
+  return isWeekend(dow) ? WEEKEND_CLOSE_HOUR : WEEKDAY_CLOSE_HOUR;
+}
+
+type PtParts = {
+  year: string;
+  month: string;
+  day: string;
+  hour: number;
+  minute: number;
+  /** 0 = Sun .. 6 = Sat */
+  dow: number;
+};
+
+/** Parse `now` into PT date-time components + PT day-of-week, DST-aware. */
+function getPtParts(now: Date): PtParts {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: TZ,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    weekday: "short",
+  });
+  const parts = Object.fromEntries(fmt.formatToParts(now).map((p) => [p.type, p.value]));
+  // Normalise the 24-hour edge: some runtimes return "24" for midnight.
+  const rawHour = parseInt(parts.hour ?? "0", 10);
+  const hour = rawHour === 24 ? 0 : rawHour;
+  const dowMap: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+  const dow = dowMap[parts.weekday ?? "Sun"] ?? 0;
+  return {
+    year: parts.year,
+    month: parts.month,
+    day: parts.day,
+    hour,
+    minute: parseInt(parts.minute ?? "0", 10),
+    dow,
+  };
+}
+
+/** True when lineup changes are allowed. */
 export function isLineupChangeWindowOpen(now: Date = new Date()): boolean {
-  const h = pacificHour(now);
-  // Open: 15-23 or 0-5  →  Closed: 6-14
-  return h >= WINDOW_OPEN_HOUR || h < WINDOW_CLOSE_HOUR;
+  const { hour, dow } = getPtParts(now);
+  const closeHour = getWindowCloseHour(dow);
+  return hour >= WINDOW_OPEN_HOUR || hour < closeHour;
 }
 
 /**
- * Returns the current window status and the next open/close boundaries.
+ * Build a Date at a target PT hour relative to `now`, DST-aware.
+ *
+ * `dayOffset` is the number of PT days forward (0 = today PT, 1 = tomorrow PT).
+ * We add `dayOffset * 24h + (targetHour - nowHour)h` to `now`, then snap via a
+ * round-trip through the formatter to correct any DST drift.
+ */
+function ptDateAtHour(now: Date, nowParts: PtParts, targetHour: number, dayOffset: number): Date {
+  const deltaHours = dayOffset * 24 + (targetHour - nowParts.hour);
+  const deltaMinutes = -nowParts.minute;
+  const candidate = new Date(now.getTime() + deltaHours * 3_600_000 + deltaMinutes * 60_000);
+
+  // DST edge: if the candidate's PT hour differs by ±1h, nudge back to the correct hour.
+  const check = getPtParts(candidate);
+  if (check.hour !== targetHour) {
+    return new Date(candidate.getTime() + (targetHour - check.hour) * 3_600_000);
+  }
+  return candidate;
+}
+
+/**
+ * Current window status plus the next open/close boundaries.
  *
  * `opensAt`  — next time the window opens  (only meaningful when currently closed)
  * `closesAt` — next time the window closes (only meaningful when currently open)
@@ -42,61 +101,48 @@ export function getWindowStatus(now: Date = new Date()): {
   opensAt: Date;
   closesAt: Date;
 } {
-  const open = isLineupChangeWindowOpen(now);
+  const parts = getPtParts(now);
+  const { hour, dow } = parts;
+  const closeHourToday = getWindowCloseHour(dow);
+  const open = hour >= WINDOW_OPEN_HOUR || hour < closeHourToday;
 
-  // Build a Date in Pacific by formatting and parsing components
-  const fmt = new Intl.DateTimeFormat("en-US", {
-    timeZone: TZ,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-  });
-  const parts = Object.fromEntries(fmt.formatToParts(now).map((p) => [p.type, p.value]));
-  const h = parseInt(parts.hour ?? "0", 10);
+  // opensAt: next 15:00 PT. Today if hour < 15, else tomorrow.
+  const opensAt =
+    hour < WINDOW_OPEN_HOUR
+      ? ptDateAtHour(now, parts, WINDOW_OPEN_HOUR, 0)
+      : ptDateAtHour(now, parts, WINDOW_OPEN_HOUR, 1);
 
-  // Helper: build a Date from Pacific-time components
-  const ptDate = (year: string, month: string, day: string, hour: number) => {
-    // Build an ISO-ish string and resolve via the formatter round-trip
-    const iso = `${year}-${month}-${day}T${String(hour).padStart(2, "0")}:00:00`;
-    // Create in UTC then adjust — simpler: use a known offset approach
-    // We rely on the fact that PT is UTC-8 (PST) or UTC-7 (PDT).
-    // Instead, just compute the delta from `now`.
-    const nowH = h;
-    let deltaHours = hour - nowH;
-    if (open) {
-      // closesAt: next WINDOW_CLOSE_HOUR
-      if (hour <= nowH) deltaHours += 24; // tomorrow
-    } else {
-      // opensAt: next WINDOW_OPEN_HOUR
-      if (hour <= nowH) deltaHours += 24;
-    }
-    const target = new Date(now.getTime() + deltaHours * 3600_000);
-    // Zero out minutes/seconds
-    target.setMinutes(0, 0, 0);
-    // Adjust for any partial-hour offset: snap to the exact hour boundary
-    const targetH = pacificHour(target);
-    if (targetH !== hour) {
-      // DST edge — nudge by 1h
-      target.setTime(target.getTime() + (hour - targetH) * 3600_000);
-    }
-    return target;
-  };
-
-  if (open) {
-    // Next close is at WINDOW_CLOSE_HOUR
-    const closesAt = ptDate(parts.year, parts.month, parts.day, WINDOW_CLOSE_HOUR);
-    // Next open is at WINDOW_OPEN_HOUR (could be today if before 3 PM, else tomorrow)
-    const opensAt = ptDate(parts.year, parts.month, parts.day, WINDOW_OPEN_HOUR);
-    return { open, opensAt, closesAt };
+  // closesAt: next close hour.
+  // If currently open (hour >= 15), close happens tomorrow — use tomorrow's DOW.
+  // If hour < closeHourToday, close happens today.
+  // (When closed mid-day, "next close" is tomorrow's close — after reopen at 15:00.)
+  let closesAt: Date;
+  if (hour < closeHourToday) {
+    closesAt = ptDateAtHour(now, parts, closeHourToday, 0);
   } else {
-    // Next open is at WINDOW_OPEN_HOUR today
-    const opensAt = ptDate(parts.year, parts.month, parts.day, WINDOW_OPEN_HOUR);
-    // Next close is at WINDOW_CLOSE_HOUR tomorrow
-    const closesAt = ptDate(parts.year, parts.month, parts.day, WINDOW_CLOSE_HOUR);
-    return { open, opensAt, closesAt };
+    const tomorrowDow = (dow + 1) % 7;
+    const closeHourTomorrow = getWindowCloseHour(tomorrowDow);
+    closesAt = ptDateAtHour(now, parts, closeHourTomorrow, 1);
   }
+
+  return { open, opensAt, closesAt };
+}
+
+/** Format a Date in PT / ET / IST for UI display. */
+export function formatWindowBoundary(d: Date): { pt: string; et: string; ist: string } {
+  const fmt = (tz: string) =>
+    d.toLocaleString("en-US", {
+      timeZone: tz,
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    });
+  return {
+    pt: fmt("America/Los_Angeles"),
+    et: fmt("America/New_York"),
+    ist: fmt("Asia/Kolkata"),
+  };
 }


### PR DESCRIPTION
Closes #56.

## Schedule
| Day | Locked (matches live) | Open (changes allowed) |
|---|---|---|
| Mon–Fri | 6 AM – 3 PM PT | 3 PM – 6 AM (next) PT |
| Sat/Sun | **3 AM** – 3 PM PT | 3 PM – **3 AM** (next) PT |

Weekend matches start at 3 AM PT, so the close hour shifts earlier on Sat/Sun.

## Changes
- `lib/lineup-lock.ts` — day-aware close hour, DST-aware `ptDateAtHour` helper, new `formatWindowBoundary()` → `{pt, et, ist}`.
- `lib/lineup-lock.test.ts` — 27 tests (was 13) including weekend boundaries and DST spring-forward / fall-back transitions.
- `app/api/private-team/lineup/route.ts` — returns `403 LINEUP_LOCKED` with `opens_at` when window is closed. Bypass for first-ever XI confirmation (requires non-empty XI, so empty-XI wipes during lock are blocked).
- `components/private-league/PrivateLineupPanel.tsx` — disables controls, shows lock banner with PT/ET/IST times, polls every 30 s for auto-transition, `router.refresh()` + local `confirmedLocally` state after save so lock kicks in immediately after first confirmation.
- `app/(app)/league/private/[leagueId]/page.tsx` — passes `xiConfirmed` prop.

## Review
Reviewed with GPT-5.4 and Claude Opus 4.7 in parallel. Both flagged two issues which are now fixed in this PR:
1. Empty-XI wipe loophole via `xi_confirmed_at=null` bypass — fixed with `&& xi.length > 0` guard.
2. Stale client lock state after first save — fixed with `confirmedLocally` + `router.refresh()`.
3. DST test coverage was missing — added three fall-back / spring-forward fixtures.

## Tests
- 171 vitest suite → 27 of those in `lineup-lock.test.ts` (up from 13).
- `tsc --noEmit` clean.

## Out of scope
- Per-league configurable windows (issue mentions as "Consideration") — defer.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>