### PR TITLE
Add NEXT_PUBLIC_LINEUP_LOCK_OVERRIDE env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ CRICAPI_DAILY_MATCH_DATE=
 CRICAPI_IPL_SERIES_ID=
 # Optional extra gate on team short / full names in currentMatches.
 CRICAPI_IPL_TEAM_SUBSTRINGS=
+
+# Set to "1" to bypass the Playing XI lock window entirely (host-initiated
+# exception, e.g., postponed match day). Leave unset/empty for normal behaviour.
+# Read on both server and client (NEXT_PUBLIC_*).
+NEXT_PUBLIC_LINEUP_LOCK_OVERRIDE=

--- a/lib/lineup-lock.ts
+++ b/lib/lineup-lock.ts
@@ -63,8 +63,25 @@ function getPtParts(now: Date): PtParts {
   };
 }
 
+/**
+ * Returns true if the lineup-lock override flag is enabled.
+ *
+ * The flag is read from `NEXT_PUBLIC_LINEUP_LOCK_OVERRIDE` so it works on
+ * both the server and the browser. Any value matching /^(1|true|yes|on)$/i
+ * disables the lock entirely (window is always "open").
+ *
+ * Intended for rare host-initiated exceptions (e.g., postponed match days).
+ * Unset the env var and redeploy to restore normal behaviour.
+ */
+export function isLineupLockOverrideEnabled(): boolean {
+  const raw = process.env.NEXT_PUBLIC_LINEUP_LOCK_OVERRIDE;
+  if (!raw) return false;
+  return /^(1|true|yes|on)$/i.test(raw.trim());
+}
+
 /** True when lineup changes are allowed. */
 export function isLineupChangeWindowOpen(now: Date = new Date()): boolean {
+  if (isLineupLockOverrideEnabled()) return true;
   const { hour, dow } = getPtParts(now);
   const closeHour = getWindowCloseHour(dow);
   return hour >= WINDOW_OPEN_HOUR || hour < closeHour;
@@ -104,7 +121,8 @@ export function getWindowStatus(now: Date = new Date()): {
   const parts = getPtParts(now);
   const { hour, dow } = parts;
   const closeHourToday = getWindowCloseHour(dow);
-  const open = hour >= WINDOW_OPEN_HOUR || hour < closeHourToday;
+  const overrideOn = isLineupLockOverrideEnabled();
+  const open = overrideOn || hour >= WINDOW_OPEN_HOUR || hour < closeHourToday;
 
   // opensAt: next 15:00 PT. Today if hour < 15, else tomorrow.
   const opensAt =


### PR DESCRIPTION
Adds a host-initiated bypass for the Playing XI lock window. Set `NEXT_PUBLIC_LINEUP_LOCK_OVERRIDE=1` (or `true`/`yes`/`on`) on Vercel to treat the lock as always open; unset and redeploy to restore normal behaviour.

- Read on both server and client (same env var, NEXT_PUBLIC prefix).
- Tests still pass (27/27 on lineup-lock).
- No breaking change when the var is unset (default false).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>